### PR TITLE
Fix typo

### DIFF
--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -40,7 +40,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
     public function handle()
     {
 
-        $this->className = $this->askToPickModel(config('factories-reloaded.models_path'));
+        $this->className = $this->askToPickModels(config('factories-reloaded.models_path'));
 
         $this->info("Thank you! $this->className it is.");
         $classPath = config('factories-reloaded.factories_path').'/'.$this->className.'Factory.php';


### PR DESCRIPTION
There is no `askToPickModel()` method on the `Christophrumpel\LaravelCommandFilePicker\Traits\PicksClasses` trait. Therefore, I think it is a typo and the `askToPickModels()` method is meant instead.

Source: https://github.com/christophrumpel/laravel-command-file-picker/blob/master/src/Traits/PicksClasses.php