### PR TITLE
Adding factories namespace on creation

### DIFF
--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -60,7 +60,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
 
         $this->files->put($classPath, $this->sortImports($this->buildClass($this->fullClassName)));
 
-        $this->info($this->type.' created successfully.');
+        $this->info(config('factories-reloaded.factories_namespace') . '\\' . $this->className.$this->type . ' created successfully.');
     }
 
     /**


### PR DESCRIPTION
adding full class namespace when making a new factory
it would be 
`Tests\Factories\UserFactory created successfully.`
instead of 
`Factory created successfully.`