### PR TITLE
Use colon notation in command signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ composer require christophrumpel/laravel-factories-reloaded
 
 First, you need to create a new factory class. This is done via a new command this package comes with. In this example, we want to create a new user factory.
 
-``` php
-php artisan make:factoryReloaded
+```php
+php artisan make:factory-reloaded
 ```
 
 After running this command, you have to select one of your models. Here you decide for which model you are creating a factory for. I will choose the user model. (Through a config you can define where your models live)

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -14,7 +14,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:factory:reloaded';
+    protected $signature = 'make:factory-reloaded';
 
     /**
      * The console command description.

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -14,7 +14,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:factoryReloaded';
+    protected $signature = 'make:factory:reloaded';
 
     /**
      * The console command description.

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -5,7 +5,6 @@ namespace Christophrumpel\LaravelFactoriesReloaded\Tests;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Config;
-use Christophrumpel\LaravelFactoriesReloaded\LaravelFactoriesReloadedServiceProvider;
 
 class FactoryCommandTest extends TestCase
 {
@@ -18,13 +17,13 @@ class FactoryCommandTest extends TestCase
         // Set to a path with no models given
         Config::set('factories-reloaded.models_path', __DIR__.'/');
 
-        $this->artisan('make:factoryReloaded');
+        $this->artisan('make:factory:reloaded');
     }
 
     /** @test */
     public function it_creates_factory_for_chosen_model()
     {
-        $this->artisan('make:factoryReloaded')
+        $this->artisan('make:factory:reloaded')
             ->expectsQuestion('Please pick a model',
                 '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->expectsOutput('Tests\Factories\GroupFactory created successfully.')
@@ -38,7 +37,7 @@ class FactoryCommandTest extends TestCase
      **/
     public function it_replaces_the_the_dummy_code_in_the_new_factory_class()
     {
-        $this->artisan('make:factoryReloaded')
+        $this->artisan('make:factory:reloaded')
             ->expectsQuestion('Please pick a model',
                 '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->assertExitCode(0);
@@ -55,11 +54,11 @@ class FactoryCommandTest extends TestCase
     ///** @test */
     //public function it_fails_if_factory_already_given()
     //{
-    //    $this->artisan('make:factoryReloaded')
+    //    $this->artisan('make:factory:reloaded')
     //        ->expectsQuestion('For which model do you want to create a Factory?',
     //            'Christophrumpel\LaravelFactoriesReloaded\Tests\Recipe');
     //
-    //    $this->artisan('make:factoryReloaded')
+    //    $this->artisan('make:factory:reloaded')
     //        ->expectsQuestion('For which model do you want to create a Factory?',
     //            'Christophrumpel\LaravelFactoriesReloaded\Tests\Recipe')
     //        ->expectsOutput('Factory already exists!')

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -17,13 +17,13 @@ class FactoryCommandTest extends TestCase
         // Set to a path with no models given
         Config::set('factories-reloaded.models_path', __DIR__.'/');
 
-        $this->artisan('make:factory:reloaded');
+        $this->artisan('make:factory-reloaded');
     }
 
     /** @test */
     public function it_creates_factory_for_chosen_model()
     {
-        $this->artisan('make:factory:reloaded')
+        $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model',
                 '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->expectsOutput('Tests\Factories\GroupFactory created successfully.')
@@ -37,7 +37,7 @@ class FactoryCommandTest extends TestCase
      **/
     public function it_replaces_the_the_dummy_code_in_the_new_factory_class()
     {
-        $this->artisan('make:factory:reloaded')
+        $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model',
                 '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->assertExitCode(0);
@@ -54,11 +54,11 @@ class FactoryCommandTest extends TestCase
     ///** @test */
     //public function it_fails_if_factory_already_given()
     //{
-    //    $this->artisan('make:factory:reloaded')
+    //    $this->artisan('make:factory-reloaded')
     //        ->expectsQuestion('For which model do you want to create a Factory?',
     //            'Christophrumpel\LaravelFactoriesReloaded\Tests\Recipe');
     //
-    //    $this->artisan('make:factory:reloaded')
+    //    $this->artisan('make:factory-reloaded')
     //        ->expectsQuestion('For which model do you want to create a Factory?',
     //            'Christophrumpel\LaravelFactoriesReloaded\Tests\Recipe')
     //        ->expectsOutput('Factory already exists!')


### PR DESCRIPTION
Maybe this is a personal choice, but I would prefer to use colon notation as some kind of namespace instead of camelcase when calling the command, we use this approach a lot at our company like

```
php artisan weather:update:current
php artisan weather:update:forecast

php artisan make:migration:client
php artisan migrate:client
```

This is also helpful when listing all the available commands with `php artisan`:

```
weather
   weather:update:current                              Update the current weather values using Dark Sky Api
   weather:update:forecast                             Update the forecast weather values using Dark Sky Api
```