### PR TITLE
Prevent showing factored model 

### DIFF
--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -38,6 +38,9 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
      */
     public function handle()
     {
+        //we will generate the path to the location where this class' file should get written
+        $this->makeDirectory(config('factories-reloaded.factories_path'));
+
         $this->fullClassName = $this->askToPickModels(config('factories-reloaded.models_path'));
         $this->className = class_basename($this->fullClassName);
 
@@ -53,14 +56,26 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
             return false;
         }
 
-        // Next, we will generate the path to the location where this class' file should get
-        // written. Then, we will build the class and make the proper replacements on the
+        //we will build the class and make the proper replacements on the
         // stub files so that it gets the correctly formatted namespace and class name.
-        $this->makeDirectory($classPath);
-
         $this->files->put($classPath, $this->sortImports($this->buildClass($this->fullClassName)));
 
         $this->info(config('factories-reloaded.factories_namespace') . '\\' . $this->className.$this->type . ' created successfully.');
+    }
+
+    /**
+     * Build the directory .
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function makeDirectory($path)
+    {
+        if (!$this->files->isDirectory($path)) {
+            $this->files->makeDirectory($path, 0777, true, true);
+        }
+
+        return $path;
     }
 
     /**

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -6,6 +6,7 @@ use Christophrumpel\LaravelCommandFilePicker\ClassFinder;
 use Christophrumpel\LaravelCommandFilePicker\Traits\PicksClasses;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class MakeFactoryReloadedCommand extends GeneratorCommand
 {
@@ -109,6 +110,27 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
         });
 
         return $diff;
+    }
+
+    /**
+     * Getting class name if it model and get,
+     * factory get class name without factory append.
+     *
+     * @param string $fullClassName
+     *
+     * @return string
+     */
+    protected function getClassName($fullClassName)
+    {
+        $className = class_basename($fullClassName);
+
+        if(!Str::contains($className,$this->type)) {
+           return $className;
+        }
+
+        $className = Str::before($className,$this->type);
+
+        return $className;
     }
 
     /**

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -5,6 +5,7 @@ namespace Christophrumpel\LaravelFactoriesReloaded\Commands;
 use Christophrumpel\LaravelCommandFilePicker\ClassFinder;
 use Christophrumpel\LaravelCommandFilePicker\Traits\PicksClasses;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Collection;
 
 class MakeFactoryReloadedCommand extends GeneratorCommand
 {
@@ -44,7 +45,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
 
         $models = $this->getModelsDontHasFactory(config('factories-reloaded.factories_path'), config('factories-reloaded.models_path'));
 
-        $this->fullClassName = $this->askToPickModels(config('factories-reloaded.models_path'));
+        $this->fullClassName = $this->askChoice($models);
         $this->className = class_basename($this->fullClassName);
 
         $this->info("Thank you! $this->className it is.");
@@ -89,7 +90,7 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
      *
      * @return Illuminate\Support\Collection
      */
-    protected function getModelsDontHasFactory($factoriesPath, $modelsPath)
+    protected function getModelsDontHasFactory($factoriesPath, $modelsPath) : Collection
     {
 
         $finder = new ClassFinder($this->laravel->make('files'));

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -45,6 +45,12 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
 
         $models = $this->getModelsDontHasFactory(config('factories-reloaded.factories_path'), config('factories-reloaded.models_path'));
 
+        if($models->isEmpty())
+        {
+            $this->info("There is no more model");
+            return false;
+        }
+
         $this->fullClassName = $this->askChoice($models);
         $this->className = class_basename($this->fullClassName);
 

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -10,14 +10,12 @@ class FactoryCommandTest extends TestCase
 {
 
     /** @test */
-    public function it_fails_if_no_models_found()
+    public function it_dosenot_fails_if_no_models_found()
     {
-        $this->expectException(\LogicException::class);
-
         // Set to a path with no models given
         Config::set('factories-reloaded.models_path', __DIR__.'/');
 
-        $this->artisan('make:factory-reloaded');
+        $this->artisan('make:factory-reloaded')->expectsOutput("There is no more model");
     }
 
     /** @test */

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -21,6 +21,7 @@ class FactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_factory_for_chosen_model()
     {
+        $this->withoutExceptionHandling();
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model',
                 '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')


### PR DESCRIPTION
I will show you an example of this PR.

we use `make:factory-reloaded` command to fitch our models, considering we have these:
```PHP
[0] App\Employee
[1] App\User
[2] App\Zoo
```
when I choose `App\User`, and run the command again `make:factory-reloaded`, let us see the results **before** and **after** this PR. 

### Before
it shows all the models again and again.
```PHP
[0] App\Employee
[1] App\User
[2] App\Zoo
```

### After
it just shows the models that don't have factory, 
```PHP
[0] App\Employee
[2] App\Zoo
```
and if you delete `UserFactory`, the `User` model will be represented in the array.
```PHP
[0] App\Employee
[1] App\User
[2] App\Zoo
```

All tests are passed
thank you.