### PR TITLE
Make it PHP 7.3 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.3",
         "christophrumpel/laravel-command-file-picker": "^0.0.4",
         "illuminate/support": "^6.0",
         "laravel/framework": "^6.0",

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -8,11 +8,17 @@ use Illuminate\Support\Collection;
 abstract class BaseFactory implements FactoryInterface
 {
 
-    protected string $modelClass;
+    /**
+     * @string
+     */
+    protected $modelClass;
 
     private $relatedModel;
 
-    private string $relatedModelRelationshipName;
+    /**
+     * @string
+     */
+    private $relatedModelRelationshipName;
 
     public static function new(): self
     {
@@ -36,7 +42,9 @@ abstract class BaseFactory implements FactoryInterface
     {
         return collect()
             ->times($times)
-            ->transform(fn() => $this->create($extra));
+            ->transform(function() use ($extra) {
+                return $this->create($extra);
+           });
     }
 
     public function with(string $relatedModelClass, string $relationshipName, int $times = 1)

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -9,14 +9,14 @@ abstract class BaseFactory implements FactoryInterface
 {
 
     /**
-     * @string
+     * @var string
      */
     protected $modelClass;
 
     private $relatedModel;
 
     /**
-     * @string
+     * @var string
      */
     private $relatedModelRelationshipName;
 

--- a/src/Commands/make-factory.stub
+++ b/src/Commands/make-factory.stub
@@ -10,7 +10,7 @@ class DummyFactory extends BaseFactory
 {
 
     /**
-     * @string
+     * @var string
      */
     protected $modelClass = DummyModelClass::class;
 

--- a/src/Commands/make-factory.stub
+++ b/src/Commands/make-factory.stub
@@ -9,7 +9,10 @@ use Faker\Generator;
 class DummyFactory extends BaseFactory
 {
 
-    protected string $modelClass = DummyModelClass::class;
+    /**
+     * @string
+     */
+    protected $modelClass = DummyModelClass::class;
 
     public function create(array $extra = []): DummyModelClass
     {

--- a/tests/Factories/GroupFactory.php
+++ b/tests/Factories/GroupFactory.php
@@ -11,7 +11,7 @@ class GroupFactory extends BaseFactory
 {
 
     /**
-     * @string
+     * @var string
      */
     protected $modelClass = Group::class;
 

--- a/tests/Factories/GroupFactory.php
+++ b/tests/Factories/GroupFactory.php
@@ -10,7 +10,10 @@ use Faker\Generator;
 class GroupFactory extends BaseFactory
 {
 
-    protected string $modelClass = Group::class;
+    /**
+     * @string
+     */
+    protected $modelClass = Group::class;
 
     public function create(array $extra = []): Group
     {

--- a/tests/Factories/GroupFactoryUsingFaker.php
+++ b/tests/Factories/GroupFactoryUsingFaker.php
@@ -10,7 +10,10 @@ use Faker\Generator;
 class GroupFactoryUsingFaker extends BaseFactory implements FactoryInterface
 {
 
-    protected string $modelClass = Group::class;
+    /**
+     * @string
+     */
+    protected $modelClass = Group::class;
 
     public function create(array $extra = []): Group
     {

--- a/tests/Factories/RecipeFactory.php
+++ b/tests/Factories/RecipeFactory.php
@@ -9,7 +9,10 @@ use Faker\Generator;
 class RecipeFactory extends BaseFactory
 {
 
-    protected string $modelClass = Recipe::class;
+    /**
+     * @string
+     */
+    protected $modelClass = Recipe::class;
 
     public function create(array $extra = []): Recipe
     {

--- a/tests/Factories/RecipeFactory.php
+++ b/tests/Factories/RecipeFactory.php
@@ -10,7 +10,7 @@ class RecipeFactory extends BaseFactory
 {
 
     /**
-     * @string
+     * @var string
      */
     protected $modelClass = Recipe::class;
 


### PR DESCRIPTION
This PR lowers the requirement to PHP 7.3 to make it useable for a larger group of developers.

laravel-factories-reloaded is currently depending on PHP >= 7.4 because it uses:
 - typed properties
 - arrow function

This PR lowers the requirement to PHP 7.3 by exchanging:
 - the typed properties with docblocks
 - the arrow function with a regular function

 
