### PR TITLE
Feature - Add make method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ class UserFactory extends BaseFactory
 
     public function create(array $extra = []): User
     {
-        return parent::create($extra);
+        return parent::build($extra);
+    }
+    
+    public function make(array $extra = []): User
+    {
+        return parent::build($extra, 'make');
     }
 
     public function getData(Generator $faker): array
@@ -75,16 +80,24 @@ $user = UserFactory::new()->create();
 This will give you back a newly created user instance from the database. If you want to create multiple instances, you can use the `times` method, which will use the `create` method behind the scenes and will return you a collection of the new model instances.
 
 ``` php
-$user = UserFactory::new()->times(4);
+$user = UserFactory::new()
+    ->times(4)
+    ->create();
+```
+
+Like with Laravel factories you can also `make` a new model which gets `not` stored to the database yet.
+
+``` php
+$user = UserFactory::new()->make();
 ```
 
 ### Relations
 
-There will be times when you need to add related models to your test data. This is already pretty easy with using multiple factory classes.
+There will be situations when you need to add related models to your test data. This is already pretty easy with using multiple factory classes.
 
 ```php
 $user = UserFactory::new()->create();
-$user->recipes()->saveMany(RecipeFactory::new()->times(4));
+$user->recipes()->saveMany(RecipeFactory::new()->times(4)->create());
 ```
 
 Of course, the relations need to be set up before. Besides this, there is also an in-built solution.
@@ -138,7 +151,7 @@ class UserFactory extends BaseFactory
     public function withRecipes(int $times = 1)
     {
         $this->recipes = RecipeFactory::new()
-            ->times($times);
+            ->times($times)->make();
 
         return $this;
     }

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -19,21 +19,9 @@ abstract class BaseFactory implements FactoryInterface
         return new static;
     }
 
-    public function create(array $extra = [])
+    protected function build(array $extra = [], string $creationType = 'create')
     {
-        $model = $this->modelClass::create(array_merge($this->getData(FakerFactory::create()), $extra));
-
-        if ($this->relatedModel) {
-            $model->{$this->relatedModelRelationshipName}()
-                ->saveMany($this->relatedModel);
-        }
-
-        return $model;
-    }
-
-    public function make(array $extra = [])
-    {
-        $model = $this->modelClass::make(array_merge($this->getData(FakerFactory::create()), $extra));
+        $model = $this->modelClass::$creationType(array_merge($this->getData(FakerFactory::create()), $extra));
 
         if ($this->relatedModel) {
             $model->{$this->relatedModelRelationshipName}()

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -29,20 +29,17 @@ abstract class BaseFactory implements FactoryInterface
         }
 
         return $model;
-
     }
 
-    public function times(int $times, array $extra = []): Collection
+    public function times(int $times): CollectionFactory
     {
-        return collect()
-            ->times($times)
-            ->transform(fn() => $this->create($extra));
+        return new CollectionFactory($this->modelClass, $times, $this->getData(FakerFactory::create()));
     }
 
     public function with(string $relatedModelClass, string $relationshipName, int $times = 1)
     {
-        $this->relatedModel =$this->getFactoryFromClassName($relatedModelClass)
-                ->times($times);
+        $this->relatedModel = $this->getFactoryFromClassName($relatedModelClass)
+            ->times($times)->create();
         $this->relatedModelRelationshipName = $relationshipName;
 
         return $this;

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -39,7 +39,7 @@ abstract class BaseFactory implements FactoryInterface
     public function with(string $relatedModelClass, string $relationshipName, int $times = 1)
     {
         $this->relatedModel = $this->getFactoryFromClassName($relatedModelClass)
-            ->times($times)->create();
+            ->times($times)->make();
         $this->relatedModelRelationshipName = $relationshipName;
 
         return $this;

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -31,6 +31,18 @@ abstract class BaseFactory implements FactoryInterface
         return $model;
     }
 
+    public function make(array $extra = [])
+    {
+        $model = $this->modelClass::make(array_merge($this->getData(FakerFactory::create()), $extra));
+
+        if ($this->relatedModel) {
+            $model->{$this->relatedModelRelationshipName}()
+                ->saveMany($this->relatedModel);
+        }
+
+        return $model;
+    }
+
     public function times(int $times): CollectionFactory
     {
         return new CollectionFactory($this->modelClass, $times, $this->getData(FakerFactory::create()));

--- a/src/CollectionFactory.php
+++ b/src/CollectionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded;
+
+use Illuminate\Support\Collection;
+use Faker\Factory as FakerFactory;
+
+class CollectionFactory
+{
+
+    private string $modelClass;
+
+    private int $times;
+
+    private array $modelData;
+
+    public function __construct(string $modelClass, int $times, array $modelData)
+    {
+        $this->modelClass = $modelClass;
+        $this->times = $times;
+        $this->modelData = $modelData;
+    }
+
+    public function create(array $extra = []): Collection
+    {
+        return collect()
+            ->times($this->times)
+            ->transform(fn() => $this->modelClass::create(array_merge($this->modelData, $extra)));
+    }
+}

--- a/src/CollectionFactory.php
+++ b/src/CollectionFactory.php
@@ -23,8 +23,18 @@ class CollectionFactory
 
     public function create(array $extra = []): Collection
     {
+        return $this->build($extra);
+    }
+
+    public function make(array $extra = []): Collection
+    {
+        return $this->build($extra, 'make');
+    }
+
+    private function build(array $extra = [], string $creationType = 'create'): Collection
+    {
         return collect()
             ->times($this->times)
-            ->transform(fn() => $this->modelClass::create(array_merge($this->modelData, $extra)));
+            ->transform(fn() => $this->modelClass::$creationType(array_merge($this->modelData, $extra)));
     }
 }

--- a/src/Commands/make-factory.stub
+++ b/src/Commands/make-factory.stub
@@ -13,8 +13,13 @@ class DummyFactory extends BaseFactory
 
     public function create(array $extra = []): DummyModelClass
     {
-        return parent::create($extra);
+        return parent::build($extra);
     }
+
+    public function make(array $extra = []): DummyModelClass
+        {
+            return parent::build($extra, 'make');
+        }
 
     public function getData(Generator $faker): array
     {

--- a/tests/Factories/GroupFactory.php
+++ b/tests/Factories/GroupFactory.php
@@ -14,7 +14,12 @@ class GroupFactory extends BaseFactory
 
     public function create(array $extra = []): Group
     {
-        return parent::create($extra);
+        return parent::build($extra);
+    }
+
+    public function make(array $extra = []): Group
+    {
+        return parent::build($extra, 'make');
     }
 
     public function getData(Generator $faker): array

--- a/tests/Factories/GroupFactoryUsingFaker.php
+++ b/tests/Factories/GroupFactoryUsingFaker.php
@@ -14,7 +14,12 @@ class GroupFactoryUsingFaker extends BaseFactory implements FactoryInterface
 
     public function create(array $extra = []): Group
     {
-        return parent::create($extra);
+        return parent::build($extra);
+    }
+
+    public function make(array $extra = []): Group
+    {
+        return parent::build($extra, 'make');
     }
 
     public function getData(Generator $faker): array

--- a/tests/Factories/RecipeFactory.php
+++ b/tests/Factories/RecipeFactory.php
@@ -16,6 +16,11 @@ class RecipeFactory extends BaseFactory
         return parent::create($extra);
     }
 
+    public function make(array $extra = []): Recipe
+    {
+        return parent::make($extra);
+    }
+
     public function getData(Generator $faker): array
     {
         return [

--- a/tests/Factories/RecipeFactory.php
+++ b/tests/Factories/RecipeFactory.php
@@ -13,12 +13,12 @@ class RecipeFactory extends BaseFactory
 
     public function create(array $extra = []): Recipe
     {
-        return parent::create($extra);
+        return parent::build($extra);
     }
 
     public function make(array $extra = []): Recipe
     {
-        return parent::make($extra);
+        return parent::build($extra, 'make');
     }
 
     public function getData(Generator $faker): array

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -31,9 +31,7 @@ class FactoryCommandTest extends TestCase
         $this->assertTrue(File::exists(__DIR__.'/Factories/tmp/GroupFactory.php'));
     }
 
-    /**
-     * @test
-     **/
+    /** @test **/
     public function it_replaces_the_the_dummy_code_in_the_new_factory_class()
     {
         $this->artisan('make:factory-reloaded')
@@ -43,10 +41,12 @@ class FactoryCommandTest extends TestCase
 
         $generatedFactoryContent = file_get_contents(__DIR__.'/Factories/tmp/GroupFactory.php');
 
-        $this->assertTrue(Str::contains($generatedFactoryContent, [
+        $this->assertTrue(Str::containsAll($generatedFactoryContent, [
             'GroupFactory',
             'Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group',
             'Group',
-        ]));
+            'create(',
+            'make(',
+        ],));
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -23,17 +23,37 @@ class FactoryTest extends TestCase
     }
 
     /** @test * */
-    public function it_gives_you_a_new_factory_model_instance()
+    public function it_creates_you_a_new_factory_model_instance()
     {
         $this->assertInstanceOf(Recipe::class, RecipeFactory::new()
             ->create());
 
+        $this->assertCount(1, Recipe::all());
+
         $this->assertInstanceOf(Group::class, GroupFactory::new()
             ->create());
+
+        $this->assertCount(1, Group::all());
+
     }
 
     /** @test * */
-    public function it_gives_you_multiple_factory_model_instances()
+    public function it_makes_you_a_new_factory_model_instance_without_storing_it()
+    {
+        $this->assertInstanceOf(Recipe::class, RecipeFactory::new()
+            ->make());
+
+        $this->assertCount(0, Recipe::all());
+
+        $this->assertInstanceOf(Group::class, GroupFactory::new()
+            ->make());
+
+        $this->assertCount(0, Group::all());
+
+    }
+
+    /** @test * */
+    public function it_gives_you_a_collection_of_factory_model_instances()
     {
         $this->assertInstanceOf(Collection::class, RecipeFactory::new()
             ->times(3)
@@ -91,7 +111,6 @@ class FactoryTest extends TestCase
         $group = GroupFactory::new()
             ->with(Recipe::class, 'recipes')
             ->create();
-
 
         $this->assertEquals(1, $group->recipes->count());
         $this->assertInstanceOf(Recipe::class, $group->recipes->first());

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -53,7 +53,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test * */
-    public function it_gives_you_a_collection_of_factory_model_instances()
+    public function it_gives_you_a_collection_of_created_factory_model_instances()
     {
         $this->assertInstanceOf(Collection::class, RecipeFactory::new()
             ->times(3)
@@ -71,6 +71,28 @@ class FactoryTest extends TestCase
             ->times(12)
             ->create());
     }
+
+    /** @test * */
+    public function it_gives_you_a_collection_of_made_factory_model_instances()
+    {
+        $this->assertInstanceOf(Collection::class, RecipeFactory::new()
+            ->times(3)
+            ->make());
+
+        $this->assertCount(3, RecipeFactory::new()
+            ->times(3)
+            ->make());
+
+        $this->assertInstanceOf(Collection::class, GroupFactory::new()
+            ->times(12)
+            ->make());
+
+        $this->assertCount(12, GroupFactory::new()
+            ->times(12)
+            ->make());
+    }
+
+
 
     /** @test * */
     public function it_uses_default_model_data()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -36,14 +36,20 @@ class FactoryTest extends TestCase
     public function it_gives_you_multiple_factory_model_instances()
     {
         $this->assertInstanceOf(Collection::class, RecipeFactory::new()
-            ->times(3));
+            ->times(3)
+            ->create());
+
         $this->assertCount(3, RecipeFactory::new()
-            ->times(3));
+            ->times(3)
+            ->create());
 
         $this->assertInstanceOf(Collection::class, GroupFactory::new()
-            ->times(12));
+            ->times(12)
+            ->create());
+
         $this->assertCount(12, GroupFactory::new()
-            ->times(12));
+            ->times(12)
+            ->create());
     }
 
     /** @test * */
@@ -73,22 +79,25 @@ class FactoryTest extends TestCase
     /** @test * */
     public function it_lets_you_use_faker_for_defining_data()
     {
-        $this->assertIsString(GroupFactoryUsingFaker::new()->create()->name);
-        $this->assertIsInt(GroupFactoryUsingFaker::new()->create()->size);
+        $this->assertIsString(GroupFactoryUsingFaker::new()
+            ->create()->name);
+        $this->assertIsInt(GroupFactoryUsingFaker::new()
+            ->create()->size);
     }
 
-    /** @test **/
+    /** @test * */
     public function it_lets_you_add_a_related_model()
     {
-    	$group = GroupFactory::new()
+        $group = GroupFactory::new()
             ->with(Recipe::class, 'recipes')
             ->create();
 
-    	$this->assertEquals(1, $group->recipes->count());
-    	$this->assertInstanceOf(Recipe::class, $group->recipes->first());
+
+        $this->assertEquals(1, $group->recipes->count());
+        $this->assertInstanceOf(Recipe::class, $group->recipes->first());
     }
 
-    /** @test **/
+    /** @test * */
     public function it_lets_you_add_multiple_related_models()
     {
         $group = GroupFactory::new()


### PR DESCRIPTION
This PR adds:

- the `make` method so that the model NOT gets stored to the DB
- a new `times` implementation so that it gives you back a new `CollectionFactory` so you can chain the `create` method but you get a collection back.