### PR TITLE
Ready enough to actually show you what I'm thinking here

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ class UserFactory extends BaseFactory
 
 Inside this class, you can define the properties of the model with the `getData` method. It is very similar to what you would do with a Laravel default factory, and you can make use of Faker as well. The `create` method is only a copy of the one in the parent class `BaseFactory`. Still, we need it in our dedicated factory class so that we can define what gets returned. In our case, it is a user model. Other methods like `new` or `times` are hidden in the parent class.
 
+### Additional arguments and options
+
+If you don't want to select your model from a list, you can pass the class name of a model in your model path as an argument and your factory will immediately be created for you:
+```php
+php artisan make:factory-reloaded Ingredient
+```
+By default, this command will stop and give you an error if a factory you're trying to create already exists. You can overwrite an existing factory using the force option:
+```php
+php artisan make:factory-reloaded Ingredient --force
+```
+You can override the configurations as options as well:
+`--models_path=path/to/your/models`
+`--factories_path=path/to/your/factories`
+`--factories_namespace=Your\Factories\Namespace`
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,23 @@ By default, this command will stop and give you an error if a factory you're try
 ```php
 php artisan make:factory-reloaded Ingredient --force
 ```
-You can override the configurations as options as well:
-`--models_path=path/to/your/models`
+
+### Configuration
+You can publish a configuration file that lets you set the path to your models and factories as well as the namespace of your factories. Alternatively, you can set the configurations as options when you run the command:
+
+`--models_path=app/models`
+
 `--factories_path=path/to/your/factories`
+
 `--factories_namespace=Your\Factories\Namespace`
+
+Most people won't need to override these configuration on the fly, but if you splitting your app up into domains you might be keeping your factories closer to their models. In this case you could do something like this:
+
+```shell script
+php artisan make:factory-reloaded --models_path=app/domains/customers/models 
+    --factories_path=app/domains/customers/factories --factories_namespace=App\Domains\Customers\Factories
+```
+
 
 
 ## Usage

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -2,8 +2,10 @@
 
 namespace Christophrumpel\LaravelFactoriesReloaded\Commands;
 
+use Christophrumpel\LaravelCommandFilePicker\ClassFinder;
 use Christophrumpel\LaravelCommandFilePicker\Traits\PicksClasses;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
 
 class MakeFactoryReloadedCommand extends GeneratorCommand
 {
@@ -42,6 +44,9 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
     private $modelsPath;
 
     /** @var string */
+    private $modelFile = '';
+
+    /** @var string */
     private $factoriesPath;
 
     /** @var string */
@@ -56,7 +61,13 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
         $this->modelsPath = $this->option('models_path') ?? config('factories-reloaded.models_path');
         $this->factoriesPath = $this->option('factories_path') ?? config('factories-reloaded.factories_path');
         $this->factoriesNamespace = $this->option('factories_namespace') ?? config('factories-reloaded.factories_namespace');
-        $this->fullClassName = $this->argument('model') ?? $this->askToPickModels($this->modelsPath);
+        if ($this->argument('model')) {
+            $class_finder = new ClassFinder(new Filesystem());
+            $this->fullClassName = $class_finder->getFullyQualifiedClassNameFromFile($this->modelsPath.'/'.$this->argument('model') . '.php');
+        }
+        else {
+            $this->fullClassName = $this->askToPickModels($this->modelsPath);
+        }
 
         $this->className = class_basename($this->fullClassName);
 

--- a/src/Commands/MakeFactoryReloadedCommand.php
+++ b/src/Commands/MakeFactoryReloadedCommand.php
@@ -34,23 +34,17 @@ class MakeFactoryReloadedCommand extends GeneratorCommand
     /** @var string */
     protected $type = 'Factory';
 
-    /** @var string */
-    private $fullClassName;
+    private string $fullClassName;
 
-    /** @var string */
-    private $className;
+    private string $className;
 
-    /** @var string */
-    private $modelsPath;
+    private string $modelsPath;
 
-    /** @var string */
-    private $modelFile = '';
+    private string $modelFile;
 
-    /** @var string */
-    private $factoriesPath;
+    private string $factoriesPath;
 
-    /** @var string */
-    private $factoriesNamespace;
+    private string $factoriesNamespace;
 
     /**
      * Execute the console command.

--- a/tests/Database/migrations/2020_01_30_0000_create_ingredients_table.php
+++ b/tests/Database/migrations/2020_01_30_0000_create_ingredients_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateIngredientsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ingredients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('ingredients');
+    }
+}

--- a/tests/Factories/tmp/IngredientFactory.php
+++ b/tests/Factories/tmp/IngredientFactory.php
@@ -3,8 +3,8 @@
 namespace ChristophrumpelLaravelFactoriesReloadedTestsFactories;
 
 use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Models\Ingredient;
 use Faker\Generator;
-use Ingredient;
 
 class IngredientFactory extends BaseFactory
 {

--- a/tests/Factories/tmp/IngredientFactory.php
+++ b/tests/Factories/tmp/IngredientFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ChristophrumpelLaravelFactoriesReloadedTestsFactories;
+
+use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use Faker\Generator;
+use Ingredient;
+
+class IngredientFactory extends BaseFactory
+{
+
+    protected string $modelClass = Ingredient::class;
+
+    public function create(array $extra = []): Ingredient
+    {
+        return parent::build($extra);
+    }
+
+    public function make(array $extra = []): Ingredient
+    {
+        return parent::build($extra, 'make');
+    }
+
+    public function getData(Generator $faker): array
+    {
+        return [];
+    }
+
+}
+

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -103,4 +103,27 @@ class FactoryCommandTest extends TestCase
 
         $this->assertTrue(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
     }
+
+    /** @test */
+    public function it_can_find_models_in_passed_models_path()
+    {
+        if (file_exists(__DIR__.'/Factories/tmp/IngredientFactory.php')) {
+            unlink(__DIR__.'/Factories/tmp/IngredientFactory.php');
+        }
+
+        Config::set('factories-reloaded.models_path', '');
+        Config::set('factories-reloaded.factories_path', '');
+        Config::set('factories-reloaded.factories_namespace', '');
+
+        $this->assertFalse(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
+
+        $this->artisan('make:factory-reloaded Ingredient
+                --models_path='.__DIR__.'/Models/Models
+                --factories_path='.__DIR__.'/Factories/tmp
+                --factories_namespace=Christophrumpel\LaravelFactoriesReloaded\Tests\Factories
+             ')
+            ->assertExitCode(0);
+
+        $this->assertTrue(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
+    }
 }

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -15,7 +15,7 @@ class FactoryCommandTest extends TestCase
         $this->expectException(\LogicException::class);
 
         // Set to a path with no models given
-        Config::set('factories-reloaded.models_path', __DIR__.'/');
+        Config::set('factories-reloaded.models_path', __DIR__ . '/');
 
         $this->artisan('make:factory-reloaded');
     }
@@ -25,21 +25,21 @@ class FactoryCommandTest extends TestCase
     {
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model',
-                '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
+                '<href=file://' . __DIR__ . '/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->assertExitCode(0);
 
-        $this->assertTrue(File::exists(__DIR__.'/Factories/tmp/GroupFactory.php'));
+        $this->assertTrue(File::exists(__DIR__ . '/Factories/tmp/GroupFactory.php'));
     }
 
-    /** @test **/
+    /** @test * */
     public function it_replaces_the_the_dummy_code_in_the_new_factory_class()
     {
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model',
-                '<href=file://'.__DIR__.'/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
+                '<href=file://' . __DIR__ . '/Models/Group.php>Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Group</>')
             ->assertExitCode(0);
 
-        $generatedFactoryContent = file_get_contents(__DIR__.'/Factories/tmp/GroupFactory.php');
+        $generatedFactoryContent = file_get_contents(__DIR__ . '/Factories/tmp/GroupFactory.php');
 
         $this->assertTrue(Str::containsAll($generatedFactoryContent, [
             'GroupFactory',
@@ -48,5 +48,59 @@ class FactoryCommandTest extends TestCase
             'create(',
             'make(',
         ],));
+    }
+
+    /** @test */
+    public function it_accepts_a_model_name_as_an_argument()
+    {
+        if (file_exists(__DIR__.'/Factories/tmp/IngredientFactory.php')) {
+            unlink(__DIR__.'/Factories/tmp/IngredientFactory.php');
+        }
+        $this->assertFalse(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
+
+        $this->artisan('make:factory-reloaded Ingredient')
+            ->assertExitCode(0);
+
+        $this->assertTrue(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
+    }
+
+    /** @test */
+    public function it_fails_if_factory_already_exists_without_force()
+    {
+        $this->artisan('make:factory-reloaded Ingredient')
+            ->expectsOutput('Factory already exists!');
+    }
+
+    /** @test */
+    public function it_succeeds_if_factory_already_exists_with_force()
+    {
+        $this->artisan('make:factory-reloaded Ingredient --force')
+            ->expectsOutput('Christophrumpel\LaravelFactoriesReloaded\Tests\Factories\IngredientFactory created successfully.');
+    }
+
+
+
+    /** @test */
+    public function it_accepts_config_as_options()
+    {
+        if (file_exists(__DIR__.'/Factories/tmp/IngredientFactory.php')) {
+            unlink(__DIR__.'/Factories/tmp/IngredientFactory.php');
+        }
+
+        Config::set('factories-reloaded.models_path', '');
+        Config::set('factories-reloaded.factories_path', '');
+        Config::set('factories-reloaded.factories_namespace', '');
+
+
+        $this->assertFalse(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
+
+        $this->artisan('make:factory-reloaded Ingredient
+                --models_path='.__DIR__.'/Models
+                --factories_path='.__DIR__.'/Factories/tmp
+                --factories_namespace=Christophrumpel\LaravelFactoriesReloaded\Tests\Factories
+             ')
+            ->assertExitCode(0);
+
+        $this->assertTrue(File::exists(__DIR__ . '/Factories/tmp/IngredientFactory.php'));
     }
 }

--- a/tests/Models/Ingredient.php
+++ b/tests/Models/Ingredient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ingredient extends Model
+{
+    protected $fillable = ['name', 'description'];
+}

--- a/tests/Models/Models/Ingredient.php
+++ b/tests/Models/Models/Ingredient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\Tests\Models\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ingredient extends Model
+{
+    protected $fillable = ['name', 'description'];
+}


### PR DESCRIPTION
@christophrumpel Here's what I've done so far:

* Added a test to make sure that the command stops and errors if a factory exists without --force
* Added a test to make sure that --force works
* Added {model?} to the signature and use it as the model class if provided
* Added an option to the signature corresponding to each of the 3 config options for on the fly configuration
* Updated docs
* Tested my changes to the command

My thinking behind using options to override the configuration settings is that for apps that are set up to use domains these paths and namespaces can vary.

I'm not married to my solutions here and would welcome any suggestions for a different way of going about any of it. Let me know if there's anything you'd like me to change or build out further. Thanks for a great package!

This pull request is in reference to #11 