### PR TITLE
 Allow higher versions of Laravel 7 (illuminate/support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4",
-        "illuminate/support": "^6.0|7.0",
+        "illuminate/support": "^6.0|^7.0",
         "laravel/framework": "^6.0|^7.0",
         "christophrumpel/laravel-command-file-picker": "^0.0.7",
         "nikic/php-parser": "^4.3"


### PR DESCRIPTION
I have made a mistake in https://github.com/christophrumpel/laravel-factories-reloaded/pull/18/files and forgot the caret. Sorry!