### PR TITLE
add @return static docblock

### DIFF
--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -23,6 +23,7 @@ abstract class BaseFactory implements FactoryInterface
         $this->faker = $faker;
     }
 
+    /** @return static */
     public static function new(): self
     {
         $faker = FakerFactory::create(config('app.faker_locale', 'en_US'));


### PR DESCRIPTION
Adding `@return static`  will help VS Code and [Intelephense extension](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client) to know about and autocomplete the methods that are  available on the subclass. 