### PR TITLE
Add failing tests for branch scenario

### DIFF
--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -75,9 +75,14 @@ class FactoryFileTest extends TestCase
 
         $content = $recipeFactoryFile->render();
 
+        $this->assertFalse(Str::containsAll($content, [
+            'factory(Group::class)',
+        ]));
+
         $this->assertTrue(Str::containsAll($content, [
             'public function withGroup',
             'public function withDifferentGroup',
+            'GroupFactory::new()->create()->id',
         ]));
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -112,6 +112,7 @@ class FactoryTest extends TestCase
 
         $this->assertEquals('Family Rumpel', GroupFactory::new()
             ->create()->name);
+
         $this->assertEquals(2, GroupFactory::new()
             ->create()->size);
     }

--- a/tests/Models/Recipe.php
+++ b/tests/Models/Recipe.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class Recipe extends Model
 {
-    protected $fillable = ['name', 'description'];
+    protected $fillable = ['name', 'description', 'group_id'];
 }

--- a/tests/database/factories/RecipeFactory.php
+++ b/tests/database/factories/RecipeFactory.php
@@ -10,6 +10,7 @@ $factory->define(Recipe::class, function (Faker $faker) {
     return [
         'name' => $faker->word,
         'description' => $faker->sentence,
+        'group_id' => factory(Group::class)
     ];
 });
 


### PR DESCRIPTION
This PR `will` convert used Laravel factories to new factory classes.

Currently, in Laravel, you can define relationships in your factories through factories. This looks like that:

```php
$factory->define(Recipe::class, function (Faker $faker) {
    return [
        'name' => $faker->word,
        'description' => $faker->sentence,
        'group_id' => factory(Group::class)
    ];
});
```

Or also in a state like that:

```php

$factory->state(Recipe::class, 'withDifferentGroup', function() {
    return [
        'group_id' => factory(Group::class)
    ];
});
```

Laravel is smart enough to get set the id from the created factory to set the relationship.

With our package, we `do not want` to use Laravel factories anymore. This is why we convert imported defaults and states to use new factory classes like this:

```php
public function getDefaults(Generator $faker): array
{
    return [
         'name' => $faker->name,
        'description' => 'Our family lasagne recipe.',
         'group_id' => GroupFactory::new()->create()->id,
    ];
}
```

and

```php
public function withGroup(): RecipeFactory
{
    $this->overwrite([
        'group_id' => GroupFactory::new()->create(),
    ]);
    
    return $this;
}
```