### PR TITLE
[Feature] Use different models for generated factories tests

### DIFF
--- a/example/tests/Factories/RecipeFactory.php
+++ b/example/tests/Factories/RecipeFactory.php
@@ -23,7 +23,7 @@ class RecipeFactory extends BaseFactory
     public function getDefaults(Generator $faker): array
     {
         return [
-            'name' => $faker->name,
+            'name' => 'Lasagne',
             'description' => 'Our family lasagne recipe.'
         ];
     }

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -29,7 +29,7 @@ class FactoryCommandTest extends TestCase
             ->expectsQuestion('Please pick a model', $this->modelAnswer(Group::class))
             ->assertExitCode(0);
 
-        $this->assertFileExists($this->exampleFactoriesPath('/GroupFactory.php'));
+        $this->assertFileExists($this->exampleFactoriesPath('GroupFactory.php'));
     }
 
     /** @test */

--- a/tests/FactoryCommandTest.php
+++ b/tests/FactoryCommandTest.php
@@ -25,23 +25,16 @@ class FactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_factory_for_chosen_model(): void
     {
-        File::delete($this->exampleFactoriesPath('GroupFactory.php'));
-
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model', $this->modelAnswer(Group::class))
             ->assertExitCode(0);
 
-        $this->assertFileExists($this->exampleFactoriesPath('GroupFactory.php'));
+        $this->assertFileExists($this->exampleFactoriesPath('/GroupFactory.php'));
     }
 
     /** @test */
     public function it_creates_factories_for_all_models(): void
     {
-        File::delete([
-            $this->exampleFactoriesPath('GroupFactory.php'),
-            $this->exampleFactoriesPath('RecipeFactory.php'),
-        ]);
-
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model', 'All')
             ->expectsQuestion('You have defined states in your old factories, do you want to import them to your new factory classes?', 'No')
@@ -56,8 +49,6 @@ class FactoryCommandTest extends TestCase
     /** @test */
     public function it_asks_user_to_integrate_old_factory_states_if_given_which_he_agrees_to(): void
     {
-        File::delete($this->exampleFactoriesPath('RecipeFactory.php'));
-
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model', $this->modelAnswer(Recipe::class))
             ->expectsQuestion('You have defined states in your old factory, do you want to import them to your new factory class?',
@@ -76,8 +67,6 @@ class FactoryCommandTest extends TestCase
     /** @test */
     public function it_asks_user_to_integrate_old_factory_states_if_given_which_he_denies(): void
     {
-        File::delete($this->exampleFactoriesPath('RecipeFactory.php'));
-
         $this->artisan('make:factory-reloaded')
             ->expectsQuestion('Please pick a model', $this->modelAnswer(Recipe::class))
             ->expectsQuestion('You have defined states in your old factory, do you want to import them to your new factory class?',

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -105,7 +105,7 @@ class FactoryFileTest extends TestCase
     public function it_gives_factory_class_full_name(): void
     {
         $recipeFactoryFile = FactoryFile::forModel(Recipe::class);
-        $this->assertEquals('ExampleAppTests\Factories\Tmp\RecipeFactory', $recipeFactoryFile->getTargetClassFullName());
+        $this->assertEquals(config('factories-reloaded.factories_namespace').'\RecipeFactory', $recipeFactoryFile->getTargetClassFullName());
     }
 
     /** @test **/

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -105,7 +105,7 @@ class FactoryFileTest extends TestCase
     public function it_gives_factory_class_full_name(): void
     {
         $recipeFactoryFile = FactoryFile::forModel(Recipe::class);
-        $this->assertEquals(RecipeFactory::class, $recipeFactoryFile->getTargetClassFullName());
+        $this->assertEquals('ExampleAppTests\Factories\Tmp\RecipeFactory', $recipeFactoryFile->getTargetClassFullName());
     }
 
     /** @test **/

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -134,6 +134,8 @@ class FactoryTest extends TestCase
     /** @test * */
     public function it_lets_you_add_a_related_model(): void
     {
+        Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories');
+
         $group = GroupFactory::new()
             ->with(Recipe::class, 'recipes')
             ->create();
@@ -145,6 +147,8 @@ class FactoryTest extends TestCase
     /** @test * */
     public function it_lets_you_add_multiple_related_models(): void
     {
+        Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories');
+
         $group = GroupFactory::new()
             ->with(Recipe::class, 'recipes', 4)
             ->create();
@@ -156,6 +160,8 @@ class FactoryTest extends TestCase
     /** @test * */
     public function the_factory_is_immutable_when_adding_related_models(): void
     {
+        Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories');
+
         $group = GroupFactory::new()
             ->with(Recipe::class, 'recipes', 4);
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -73,16 +73,6 @@ class FactoryTest extends TestCase
             ->create());
     }
 
-    /** @test * */
-    public function collection_of_factory_models_has_unique_values(): void
-    {
-        $recipes = RecipeFactory::new()
-            ->times(3)
-            ->create();
-
-        $this->assertNotEquals($recipes[0]->name, $recipes[1]->name);
-        $this->assertNotEquals($recipes[1]->name, $recipes[2]->name);
-    }
 
     /** @test * */
     public function it_gives_you_a_collection_of_made_factory_model_instances(): void
@@ -107,6 +97,8 @@ class FactoryTest extends TestCase
     /** @test * */
     public function it_uses_default_model_data(): void
     {
+        $this->assertEquals('Lasagne', RecipeFactory::new()
+            ->create()->name);
         $this->assertEquals('Our family lasagne recipe.', RecipeFactory::new()
             ->create()->description);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Christophrumpel\LaravelFactoriesReloaded\LaravelFactoriesReloadedServiceProv
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Storage;
 use ReflectionClass;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -29,14 +28,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
         Config::set('factories-reloaded.factories_path', $this->basePath . '/tests/Factories/tmp');
         Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories\Tmp');
 
-        //$this->backupExampleAppFolder();
-
         $this->loadMigrationsFrom($this->basePath . '/database/migrations');
     }
 
     public function tearDown(): void
     {
-        //$this->restoreExampleAppFolder();
         File::cleanDirectory($this->exampleFactoriesPath());
 
         parent::tearDown();
@@ -62,17 +58,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
     public function exampleFactoriesPath($path = ''): string
     {
         return Config::get('factories-reloaded.factories_path') . ($path ? DIRECTORY_SEPARATOR . $path : $path);
-    }
-
-    protected function backupExampleAppFolder(): void
-    {
-        File::copyDirectory($this->basePath, __DIR__ . '/../backup');
-    }
-
-    protected function restoreExampleAppFolder(): void
-    {
-        File::moveDirectory(__DIR__ . '/../backup', $this->basePath, true);
-        File::deleteDirectory(__DIR__ . '/../backup');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Christophrumpel\LaravelFactoriesReloaded\LaravelFactoriesReloadedServiceProv
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use ReflectionClass;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -25,17 +26,18 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         Config::set('factories-reloaded.models_paths', [$this->exampleAppPath('Models')]);
         Config::set('factories-reloaded.vanilla_factories_path', $this->basePath . '/database/factories');
-        Config::set('factories-reloaded.factories_path', $this->basePath . '/tests/Factories');
-        Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories');
+        Config::set('factories-reloaded.factories_path', $this->basePath . '/tests/Factories/tmp');
+        Config::set('factories-reloaded.factories_namespace', 'ExampleAppTests\Factories\Tmp');
 
-        $this->backupExampleAppFolder();
+        //$this->backupExampleAppFolder();
 
         $this->loadMigrationsFrom($this->basePath . '/database/migrations');
     }
 
     public function tearDown(): void
     {
-        $this->restoreExampleAppFolder();
+        //$this->restoreExampleAppFolder();
+        File::cleanDirectory($this->exampleFactoriesPath());
 
         parent::tearDown();
     }


### PR DESCRIPTION
This PR seperates the usage of class factories in the tests.

* For tests regarding the new factory class we use the given Test Factories.
* For tests about generating new class factories we store these classes in a temporary directory