### PR TITLE
Fix clone bug

### DIFF
--- a/example/database/factories/RecipeFactory.php
+++ b/example/database/factories/RecipeFactory.php
@@ -20,7 +20,9 @@ $factory->state(Recipe::class, 'withGroup', function () {
 });
 
 $factory->state(Recipe::class, 'withDifferentGroup', function () {
+    $group = factory(Group::class)->create();
+
     return [
-        'group_id' => factory(Group::class),
+        'group_id' => $group->id,
     ];
 });

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -13,15 +13,13 @@ abstract class BaseFactory implements FactoryInterface
 
     protected string $modelClass;
 
-    private Collection $relatedModels;
+    protected Collection $relatedModels;
 
-    private string $relatedModelRelationshipName;
+    protected string $relatedModelRelationshipName;
 
-    private Generator $faker;
+    protected Generator $faker;
 
-    private array
-
- $overwriteDefaults = [];
+    protected array $overwriteDefaults = [];
 
     public function __construct(Generator $faker)
     {
@@ -85,7 +83,7 @@ abstract class BaseFactory implements FactoryInterface
         return $this;
     }
 
-    private function getFactoryFromClassName(string $className): FactoryInterface
+    protected function getFactoryFromClassName(string $className): FactoryInterface
     {
         $baseClassName = (new ReflectionClass($className))->getShortName();
         $factoryClass = config('factories-reloaded.factories_namespace').'\\'.$baseClassName.'Factory';

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -76,8 +76,16 @@ abstract class BaseFactory implements FactoryInterface
         return $clone;
     }
 
-    public function overwriteDefaults(array $attributes): self
+    /**
+     * @param array|callable $attributes
+     * @return $this
+     */
+    public function overwriteDefaults($attributes): self
     {
+        if (is_callable($attributes)) {
+            $attributes = $attributes();
+        }
+
         $this->overwriteDefaults = $attributes;
 
         return $this;

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -87,12 +87,24 @@ class FactoryFileTest extends TestCase
 
         $content = $recipeFactoryFile->render();
 
-        $this->assertTrue(Str::containsAll($content, [
-            'public function withGroup',
-            '$clone = clone $this;',
-            'return $clone',
-            'public function withDifferentGroup',
-        ]));
+        $this->assertTrue(Str::contains($content, '    public function withGroup(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults([
+            \'group_id\' => factory(Group::class),
+        ]);
+    }'));
+
+        $this->assertTrue(Str::contains($content, 'public function withDifferentGroup(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults(function() {
+            $group = factory(Group::class)->create();
+
+            return [
+                \'group_id\' => $group->id,
+            ];
+        });
+    }'));
+
     }
 
     /** @test * */


### PR DESCRIPTION
Closes #37 

With this PR we generate state methods a bit different to avoid bug like this
```php
public function settings(): UserFactory
{
    $clone = clone $this;
    $settingsArray = [
        'api_key'    => 'test',
        'secret_key' => 'secret'
    ];
    $settingsString = json_encode($settingsArray);

    return [
        'settings' => $settingsString
    ]);

    return $clone;
}
```

New output will be
```php
public function settings(): UserFactory
{
    return tap(clone $this)->overwriteDefaults(function () {
        $settingsArray = [
            'api_key'    => 'test',
            'secret_key' => 'secret'
        ];
        $settingsString = json_encode($settingsArray);

        return [
            'settings' => $settingsString
        ];
    });
}
```
