### PR TITLE
Throw exception if factory state is an array during import

### DIFF
--- a/example/app/Models/ModelsWithArrayState/Book.php
+++ b/example/app/Models/ModelsWithArrayState/Book.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ExampleApp\Models\ModelsWithArrayState;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Book extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/example/database/factories/BookFactory.php
+++ b/example/database/factories/BookFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+
+$factory->define(\ExampleApp\Models\ModelsWithArrayState\Book::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+    ];
+});
+
+$factory->state(
+    \ExampleApp\Models\ModelsWithArrayState\Book::class,
+    'customName',
+    [
+        'name' => 'custom-name',
+    ]
+);

--- a/example/database/migrations/2020_01_30_0000_create_books_table.php
+++ b/example/database/migrations/2020_01_30_0000_create_books_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBooksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('books', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->integer('size');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('books');
+    }
+}

--- a/src/LaravelFactoryExtractor.php
+++ b/src/LaravelFactoryExtractor.php
@@ -204,7 +204,10 @@ class LaravelFactoryExtractor
             return '';
         }
 
+
         return collect($states->get($this->className))->map(function ($closure, $state) {
+            throw_if(! is_callable($closure), new \RuntimeException('One of your factory states is defined as an array. It must be of the type closure to import it.'));
+
             $lines = collect($this->getClosureContent($closure))->filter()->map(fn ($item) => str_replace("\n", '', $item));
             $firstLine = $lines->shift();
             $lastLine = $lines->pop();

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -5,6 +5,7 @@ namespace Christophrumpel\LaravelFactoriesReloaded\Tests;
 use Christophrumpel\LaravelFactoriesReloaded\FactoryFile;
 use ExampleApp\Models\Group;
 use ExampleApp\Models\Ingredient;
+use ExampleApp\Models\ModelsWithArrayState\Book;
 use ExampleApp\Models\Recipe;
 use Illuminate\Support\Str;
 
@@ -104,6 +105,16 @@ class FactoryFileTest extends TestCase
             ];
         });
     }'));
+    }
+
+    /** @test * */
+    public function it_throws_error_if_state_uses_array_instead_closure(): void
+    {
+        try {
+            FactoryFile::forModel(Book::class);
+        } catch (\RuntimeException $exception) {
+            $this->assertEquals('One of your factory states is defined as an array. It must be of the type closure to import it.', $exception->getMessage());
+        }
     }
 
     /** @test * */


### PR DESCRIPTION
This PR throws an exception with a helpful error message when you try to import a factory state which is defined through an array instead of a closure.

In Laravel, most factory states are defined through a `closure` like this:

```php
$factory->state(App\User::class, 'address', function ($faker) {
    return [
        'address' => $faker->address,
    ];
});
```

Technically, you can also use an array like this:

```php
$factory->state(App\User::class, 'delinquent', [
    'account_status' => 'delinquent',
]);
```

Importing old states through our package's artisan command currently only works with `closures`.  We want to allow array states in the future but currently, it is not supported.