### PR TITLE
Update to the way LaravelFactoryExtractor processes Laravel factory state methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,9 @@ You might have noticed that when this package imports a `state` for you, it will
 ```php
 public function active(): UserFactory
 {
-    $clone = clone $this;
-    $clone->overwriteDefaults([
+    return tap(clone $this)->overwriteDefaults([
         'active' => true,
     ]);
-
-    return $clone;
 }
 ```
 

--- a/example/database/factories/RecipeFactory.php
+++ b/example/database/factories/RecipeFactory.php
@@ -32,7 +32,7 @@ $factory->state(Recipe::class, 'withOneLineGroup', function () {
 });
 
 $factory->state(Recipe::class, 'withOneLineGroup2', function () {
-    ReTuRn ['group_id' => factory(Group::class)];
+    return ['group_id' => factory(Group::class)];
 });
 
 $factory->state(Recipe::class, 'withReturnGroupName', function () {

--- a/example/database/factories/RecipeFactory.php
+++ b/example/database/factories/RecipeFactory.php
@@ -26,3 +26,7 @@ $factory->state(Recipe::class, 'withDifferentGroup', function () {
         'group_id' => $group->id,
     ];
 });
+
+$factory->state(Recipe::class, 'withOneLineGroup', function () {
+    return ['group_id' => factory(Group::class)];
+});

--- a/example/database/factories/RecipeFactory.php
+++ b/example/database/factories/RecipeFactory.php
@@ -31,10 +31,6 @@ $factory->state(Recipe::class, 'withOneLineGroup', function () {
     return ['group_id' => factory(Group::class)];
 });
 
-$factory->state(Recipe::class, 'withOneLineGroup2', function () {
-    return ['group_id' => factory(Group::class)];
-});
-
 $factory->state(Recipe::class, 'withReturnGroupName', function () {
     return ['group_name' => 'return all'];
 });

--- a/example/database/factories/RecipeFactory.php
+++ b/example/database/factories/RecipeFactory.php
@@ -30,3 +30,15 @@ $factory->state(Recipe::class, 'withDifferentGroup', function () {
 $factory->state(Recipe::class, 'withOneLineGroup', function () {
     return ['group_id' => factory(Group::class)];
 });
+
+$factory->state(Recipe::class, 'withOneLineGroup2', function () {
+    ReTuRn ['group_id' => factory(Group::class)];
+});
+
+$factory->state(Recipe::class, 'withReturnGroupName', function () {
+    return ['group_name' => 'return all'];
+});
+
+$factory->state(Recipe::class, 'withSquareBracketGroupName', function () {
+    return ['group_name' => 'something];'];
+});

--- a/src/LaravelFactoryExtractor.php
+++ b/src/LaravelFactoryExtractor.php
@@ -10,9 +10,7 @@ use SplFileObject;
 
 class LaravelFactoryExtractor
 {
-    protected ?array
-
- $uses = null;
+    protected ?array $uses = null;
 
     protected string $className;
 

--- a/src/LaravelFactoryExtractor.php
+++ b/src/LaravelFactoryExtractor.php
@@ -214,9 +214,9 @@ class LaravelFactoryExtractor
 
             if (Str::startsWith(ltrim($firstLine), 'return')) {
                 if ($lastLine === null) {
-                    $firstLine = str_replace('];', ']);', $firstLine);
+                    $firstLine = Str::replaceLast('];', ']);', $firstLine);
                 } else {
-                    $lines->push(str_replace('];', ']);', $lastLine));
+                    $lines->push(Str::replaceLast('];', ']);', $lastLine));
                 }
                 $lines->push('}');
 
@@ -224,7 +224,7 @@ class LaravelFactoryExtractor
                     '',
                     'public function ' . $this->getStateMethodName($state) . '(): ' . class_basename($this->className) . 'Factory',
                     '{',
-                    str_replace('return ', 'return tap(clone $this)->overwriteDefaults(', $firstLine),
+                    Str::replaceFirst('return ', 'return tap(clone $this)->overwriteDefaults(', $firstLine),
                 ])->toArray();
             }
 

--- a/src/LaravelFactoryExtractor.php
+++ b/src/LaravelFactoryExtractor.php
@@ -202,55 +202,50 @@ class LaravelFactoryExtractor
             return '';
         }
 
-
-        return PHP_EOL . collect($states->get($this->className))->map(function ($closure, $state) {
+        return collect($states->get($this->className))->map(function ($closure, $state) {
             throw_if(
                 ! is_callable($closure),
                 new \RuntimeException('One of your factory states is defined as an array. It must be of the type closure to import it.')
             );
 
-            $lines =
-                collect($this->getClosureContent($closure))
-                ->map(fn ($item) => rtrim($item, "\r\n"))
-                ->filter();
+            $lines = collect($this->getClosureContent($closure))->filter()->map(fn ($item) => str_replace("\n", '', $item));
+            $firstLine = $lines->shift();
+            $lastLine = $lines->pop();
 
-            $returnRaw = $this->detectReturn($lines->implode(PHP_EOL));
-            if ((Str::startsWith(mb_strtolower(ltrim($lines->first())), 'return')) && (mb_strlen($returnRaw))) {
-                $method =
-                    'public function ' . $this->getStateMethodName($state) . '(): ' . class_basename($this->className) . 'Factory' . PHP_EOL
-                    . '{' . PHP_EOL
-                    . '    return tap(clone $this)->overwriteDefaults(' . $returnRaw . ');' . PHP_EOL
-                    . '}' . PHP_EOL;
-            } else {
-                $method =
-                    'public function ' . $this->getStateMethodName($state) . '(): ' . class_basename($this->className) . 'Factory' . PHP_EOL
-                    . '{' . PHP_EOL
-                    . '    return tap(clone $this)->overwriteDefaults(function() {' . PHP_EOL
-                    . $this->indent($lines->implode(PHP_EOL)) . PHP_EOL
-                    . '    });' . PHP_EOL
-                    . '}' . PHP_EOL;
+            if (Str::startsWith(ltrim($firstLine), 'return')) {
+                if ($lastLine === null) {
+                    $firstLine = str_replace('];', ']);', $firstLine);
+                } else {
+                    $lines->push(str_replace('];', ']);', $lastLine));
+                }
+                $lines->push('}');
+
+                return $lines->prepend([
+                    '',
+                    'public function ' . $this->getStateMethodName($state) . '(): ' . class_basename($this->className) . 'Factory',
+                    '{',
+                    str_replace('return ', 'return tap(clone $this)->overwriteDefaults(', $firstLine),
+                ])->toArray();
             }
 
-            return $this->indent($method);
-        })->implode(PHP_EOL);
-    }
+            return collect([
+                '',
+                'public function ' . $this->getStateMethodName($state) . '(): ' . class_basename($this->className) . 'Factory',
+                '{',
+                '    return tap(clone $this)->overwriteDefaults(function() {',
+                '    ' . $firstLine,
+            ])->merge($lines->map(fn ($line) => '    ' . $line))->merge([
+                '    ' . $lastLine,
+                '    });',
+                '}',
+            ]);
+        })->flatten()->map(function ($line) {
+            if (ltrim($line) === '') {
+                return '';
+            }
 
-    protected function detectReturn(string $lines): ?string
-    {
-        $regex = '/'
-            . 'return\s*'
-            . '('
-            . '(?:"[^"]*"|\'[^\']*\'|[^;])*' // pick all chars that aren't ";" (unless inside a quoted string)
-            . ');'
-            . '\s*/i';
-        $matched = preg_match($regex, $lines, $matches);
-
-        return ($matched) && mb_strlen($matches[1]) ? $matches[1] : null;
-    }
-
-    protected function indent(string $source): string
-    {
-        return collect(explode(PHP_EOL, $source))->map(fn ($item) => '    ' . $item)->implode(PHP_EOL);
+            return '    ' . $line;
+        })->implode("\n");
     }
 
     protected function getStateMethodName(string $state): string

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -88,6 +88,7 @@ class FactoryFileTest extends TestCase
 
         $content = $recipeFactoryFile->render();
 
+        // where the state php closure simply returns an array - but was over multiple lines of code
         $this->assertTrue(Str::contains($content, '    public function withGroup(): RecipeFactory
     {
         return tap(clone $this)->overwriteDefaults([
@@ -95,6 +96,7 @@ class FactoryFileTest extends TestCase
         ]);
     }'));
 
+        // where the state php closure does some work before returning its array of values
         $this->assertTrue(Str::contains($content, '    public function withDifferentGroup(): RecipeFactory
     {
         return tap(clone $this)->overwriteDefaults(function() {
@@ -106,9 +108,28 @@ class FactoryFileTest extends TestCase
         });
     }'));
 
+        // where the state php closure simply returns an array and was on one line
         $this->assertTrue(Str::contains($content, '    public function withOneLineGroup(): RecipeFactory
     {
         return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
+    }'));
+
+        // where the state php closure simply returns an array and was on one line - and "return" isn't all lower case
+        $this->assertTrue(Str::contains($content, '    public function withOneLineGroup2(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
+    }'));
+
+        // where the state php closure simply returns an array and was on one line - and contains the string "return " within its values
+        $this->assertTrue(Str::contains($content, '    public function withReturnGroupName(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults([\'group_name\' => \'return all\']);
+    }'));
+
+        // where the state php closure simply returns an array and was on one line - and contains the string "];" within its values
+        $this->assertTrue(Str::contains($content, '    public function withSquareBracketGroupName(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults([\'group_name\' => \'something];\']);
     }'));
     }
 

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -114,12 +114,6 @@ class FactoryFileTest extends TestCase
         return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
     }'));
 
-        // where the state php closure simply returns an array and was on one line - and "return" isn't all lower case
-        $this->assertTrue(Str::contains($content, '    public function withOneLineGroup2(): RecipeFactory
-    {
-        return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
-    }'));
-
         // where the state php closure simply returns an array and was on one line - and contains the string "return " within its values
         $this->assertTrue(Str::contains($content, '    public function withReturnGroupName(): RecipeFactory
     {

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -99,11 +99,15 @@ class FactoryFileTest extends TestCase
     {
         return tap(clone $this)->overwriteDefaults(function() {
             $group = factory(Group::class)->create();
-
             return [
                 \'group_id\' => $group->id,
             ];
         });
+    }'));
+
+        $this->assertTrue(Str::contains($content, 'public function withOneLineGroup(): RecipeFactory
+    {
+        return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
     }'));
     }
 

--- a/tests/FactoryFileTest.php
+++ b/tests/FactoryFileTest.php
@@ -95,17 +95,18 @@ class FactoryFileTest extends TestCase
         ]);
     }'));
 
-        $this->assertTrue(Str::contains($content, 'public function withDifferentGroup(): RecipeFactory
+        $this->assertTrue(Str::contains($content, '    public function withDifferentGroup(): RecipeFactory
     {
         return tap(clone $this)->overwriteDefaults(function() {
             $group = factory(Group::class)->create();
+
             return [
                 \'group_id\' => $group->id,
             ];
         });
     }'));
 
-        $this->assertTrue(Str::contains($content, 'public function withOneLineGroup(): RecipeFactory
+        $this->assertTrue(Str::contains($content, '    public function withOneLineGroup(): RecipeFactory
     {
         return tap(clone $this)->overwriteDefaults([\'group_id\' => factory(Group::class)]);
     }'));


### PR DESCRIPTION
Hi there. This PR updates the way **LaravelFactoryExtractor**'s **getStates** method processes input php code.

**The problem:**

Currently when it analyses the code inside Laravel factory state methods, there are situations where incorrect output is generated.

For example, the source:
``` php
$factory->state(Recipe::class, 'someState', function () {
    return [ 'objective' => 'return something];' ];
});
```

Will generate:
``` php
    public function someState(): RecipeFactory
    {
        return tap(clone $this)->overwriteDefaults([ 'objective' => 'return tap(clone $this)->overwriteDefaults(something];' ];

    }
```

There are three ways I identified where the input can be mis-interpreted:

- The string "return " appears on the first line of code in more than one place,
- When there's more than one line of code and the string "];" appears more than once on the last line,
- When there's only one line of code,

Also, when "return" isn't lowercase it won't be detected, and will fall-back to the longer closure return type.

**The solution:**

The proposed changes detect the return value differently (with a regex) and inserts that instead of piecing together the content from the exploded lines.

The relevant test and README.md have been updated.

**Further thoughts:**

This code still strips out empty lines and adds indentation which also have the potential to also give incorrect results.  I think that string values in the input that span multiple lines are not likely to be needed here and the user can always tweak the output, so the benefit of neater formatting is probably preferred.