### PR TITLE
generate default attributes if there isn’t an existing factory to mig…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
     ],
     "require": {
         "php": "^7.4",
+        "christophrumpel/laravel-command-file-picker": "^1.0",
+        "doctrine/dbal": "^2.10",
         "illuminate/support": "^6.0|^7.0",
         "laravel/framework": "^6.0|^7.0",
-        "christophrumpel/laravel-command-file-picker": "^1.0",
         "nikic/php-parser": "^4.3"
     },
     "require-dev": {

--- a/src/AttributeGenerator/DefaultAttributesGenerator.php
+++ b/src/AttributeGenerator/DefaultAttributesGenerator.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator;
+
+use Doctrine\DBAL\Types\Types;
+use Illuminate\Support\Collection;
+
+class DefaultAttributesGenerator
+{
+    protected Collection $definitions;
+
+    protected $fakeableTypes = [
+        //Types::ARRAY => '',
+        Types::BIGINT => '$faker->randomNumber()',
+        //Types::BINARY => '',
+        //Types::BLOB => '',
+        Types::BOOLEAN => '$faker->boolean',
+        Types::DATE_MUTABLE => '$faker->date()',
+        Types::DATE_IMMUTABLE => '$faker->date()',
+        //Types::DATEINTERVAL => '',
+        Types::DATETIME_MUTABLE => '$faker->dateTime()',
+        Types::DATETIME_IMMUTABLE => '$faker->dateTime()',
+        Types::DATETIMETZ_MUTABLE => '$faker->dateTime()',
+        Types::DATETIMETZ_IMMUTABLE => '$faker->dateTime()',
+        Types::DECIMAL => '$faker->randomFloat()',
+        Types::FLOAT => '$faker->randomFloat()',
+        Types::GUID => '$faker->word',
+        Types::INTEGER => '$faker->randomNumber()',
+        Types::JSON => "json_encode([
+            'first_name' => \$faker->firstName,
+            'last_name' => \$faker->lastName,
+            'company' => \$faker->company,
+        ])",
+        //Types::OBJECT => '',
+        //Types::SIMPLE_ARRAY => '',
+        Types::SMALLINT => '$faker->randomNumber()',
+        Types::STRING => '$faker->word',
+        Types::TEXT => '$faker->text',
+        Types::TIME_MUTABLE => '$faker->time()',
+        Types::TIME_IMMUTABLE => '$faker->time()',
+    ];
+
+    protected $fakeableNames = [
+        'city' => '$faker->city',
+        'company' => '$faker->company',
+        'country' => '$faker->country',
+        'created_at' => '\Illuminate\Support\Carbon::now()',
+        'description' => '$faker->text',
+        'email' => '$faker->safeEmail',
+        'first_name' => '$faker->firstName',
+        'firstname' => '$faker->firstName',
+        'guid' => '$faker->uuid',
+        'last_name' => '$faker->lastName',
+        'lastname' => '$faker->lastName',
+        'lat' => '$faker->latitude',
+        'latitude' => '$faker->latitude',
+        'lng' => '$faker->longitude',
+        'longitude' => '$faker->longitude',
+        'name' => '$faker->name',
+        'password' => '\Hash::make($faker->password)',
+        'phone' => '$faker->phoneNumber',
+        'phone_number' => '$faker->phoneNumber',
+        'postcode' => '$faker->postcode',
+        'postal_code' => '$faker->postcode',
+        'remember_token' => '\Str::random(10)',
+        'slug' => '$faker->slug',
+        'street' => '$faker->streetName',
+        'address1' => '$faker->streetAddress',
+        'address2' => '$faker->secondaryAddress',
+        'summary' => '$faker->text',
+        'updated_at' => '\Illuminate\Support\Carbon::now()',
+        'url' => '$faker->url',
+        'user_name' => '$faker->userName',
+        'username' => '$faker->userName',
+        'uuid' => '$faker->uuid',
+        'zip' => '$faker->postcode',
+    ];
+
+    /** @var \Illuminate\Database\Eloquent\Model */
+    protected $model;
+
+    public function __construct(string $modelClass)
+    {
+        $this->model = app($modelClass);
+        $table = $this->getTableForModel($modelClass);
+        $this->definitions = $this->generateDefinitionsFromTable($table);
+    }
+
+    public function getDefinitions()
+    {
+        return $this->definitions;
+    }
+
+    public function getDefinitionsCodeBlock(): string
+    {
+        // all the extra spaces are needed for formatting
+        return rtrim(collect([
+            "return [",
+            $this->definitions->map(fn($item, $key) => "            '$key' => $item")
+                ->implode(",\n"),
+            '        ];',
+        ])->implode("\n"));
+    }
+
+    protected function generateDefinitionsFromTable($table)
+    {
+        return app(TableColumnTypeReader::class)
+            ->getColumnTypeMap($table)
+            ->filter(function ($type, $column) {
+                // get rid of auto incrementing ids
+                if ($this->model->incrementing && ($column === $this->model->getKeyName())) {
+                    return false;
+                }
+
+                return true;
+            })
+            ->map(fn($type, $column) => $this->getColumnDefinition($column, $type));
+    }
+
+    protected function getColumnDefinition(string $name, string $type)
+    {
+        $definition = collect($this->fakeableNames)->get($name);
+
+        $definition ??= collect($this->fakeableTypes)->get($type);
+
+        $definition ??= '$faker->word';
+
+        return $definition;
+    }
+
+    protected function getTableForModel(string $modelClass)
+    {
+        $model = app($modelClass);
+
+        return $model->getConnection()
+                ->getTablePrefix().$model->getTable();
+    }
+}

--- a/src/AttributeGenerator/TableColumnTypeReader.php
+++ b/src/AttributeGenerator/TableColumnTypeReader.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator;
+
+use Doctrine\DBAL\DBALException;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Collection;
+
+class TableColumnTypeReader
+{
+    public const UNKNOWN_TYPE = 'unknown';
+
+    public function getColumnTypeMap(string $table): Collection
+    {
+        $schemaBuilder = app('db.connection')->getSchemaBuilder();
+
+        return collect($schemaBuilder->getColumnListing($table))
+            ->mapWithKeys(function ($column) use ($schemaBuilder, $table) {
+                try {
+                    return [$column => $schemaBuilder->getColumnType($table, $column)];
+                } catch (DBALException $exception) {
+                    return [$column => self::UNKNOWN_TYPE];
+                }
+            });
+    }
+}

--- a/src/FactoryFile.php
+++ b/src/FactoryFile.php
@@ -2,6 +2,7 @@
 
 namespace Christophrumpel\LaravelFactoriesReloaded;
 
+use Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator\DefaultAttributesGenerator;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
@@ -28,6 +29,9 @@ class FactoryFile
             $this->defaults = $extractor->getDefinitions();
             $this->states = $extractor->getStates();
             $this->uses = $extractor->getUses();
+        } else {
+            $generator = new DefaultAttributesGenerator($this->modelClass);
+            $this->defaults = $generator->getDefinitionsCodeBlock();
         }
     }
 

--- a/tests/AttributeGenerator/AttributeGeneraterBaseTestCase.php
+++ b/tests/AttributeGenerator/AttributeGeneraterBaseTestCase.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\Tests\AttributeGenerator;
+
+use Christophrumpel\LaravelFactoriesReloaded\Tests\TestCase;
+use Doctrine\DBAL\Types\Types;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
+
+class AttributeGeneraterBaseTestCase extends TestCase
+{
+    use InteractsWithContainer;
+
+    public static array $columnTypeMap = [
+        //'array_column' => Types::ARRAY,
+        'bigint_column' => Types::BIGINT,
+        //'binary_column' => Types::BINARY,
+        //'blob_column' => Types::BLOB,
+        'boolean_column' => Types::BOOLEAN,
+        'date_mutable_column' => Types::DATE_MUTABLE,
+        'date_immutable_column' => Types::DATE_IMMUTABLE,
+        //'dateinterval_column' => Types::DATEINTERVAL,
+        'datetime_mutable_column' => Types::DATETIME_MUTABLE,
+        'datetime_immutable_column' => Types::DATETIME_IMMUTABLE,
+        'datetimetz_mutable_column' => Types::DATETIMETZ_MUTABLE,
+        'datetimetz_immutable_column' => Types::DATETIMETZ_IMMUTABLE,
+        'decimal_column' => Types::DECIMAL,
+        'float_column' => Types::FLOAT,
+        'guid_column' => Types::GUID,
+        'integer_column' => Types::INTEGER,
+        'json_column' => Types::JSON,
+        //'object_column' => Types::OBJECT,
+        //'simple_array_column' => Types::SIMPLE_ARRAY,
+        'smallint_column' => Types::SMALLINT,
+        'string_column' => Types::STRING,
+        'text_column' => Types::TEXT,
+        'time_mutable_column' => Types::TIME_MUTABLE,
+        'time_immutable_column' => Types::TIME_IMMUTABLE,
+    ];
+
+    public static $columnTypesToFakerMap = [
+        // 'array_column' => '',
+        'bigint_column' => '$faker->randomNumber()',
+        // 'binary_column' => '',
+        // 'blob_column' => '',
+        'boolean_column' => '$faker->boolean',
+        'date_mutable_column' => '$faker->date()',
+        'date_immutable_column' => '$faker->date()',
+        // 'dateinterval_column' => '',
+        'datetime_mutable_column' => '$faker->dateTime()',
+        'datetime_immutable_column' => '$faker->dateTime()',
+        'datetimetz_mutable_column' => '$faker->dateTime()',
+        'datetimetz_immutable_column' => '$faker->dateTime()',
+        'decimal_column' => '$faker->randomFloat()',
+        'float_column' => '$faker->randomFloat()',
+        'guid_column' => '$faker->word',
+        'integer_column' => '$faker->randomNumber()',
+        'json_column' => "json_encode([
+            'first_name' => \$faker->firstName,
+            'last_name' => \$faker->lastName,
+            'company' => \$faker->company,
+        ])",
+        // 'object_column' => '',
+        // 'simple_array_column' => '',
+        'smallint_column' => '$faker->randomNumber()',
+        'string_column' => '$faker->word',
+        'text_column' => '$faker->text',
+        'time_mutable_column' => '$faker->time()',
+        'time_immutable_column' => '$faker->time()',
+    ];
+
+    public static $columnNamesToFakerMap = [
+        'city' => '$faker->city',
+        'company' => '$faker->company',
+        'country' => '$faker->country',
+        'description' => '$faker->text',
+        'email' => '$faker->safeEmail',
+        'first_name' => '$faker->firstName',
+        'firstname' => '$faker->firstName',
+        'guid' => '$faker->uuid',
+        'last_name' => '$faker->lastName',
+        'lastname' => '$faker->lastName',
+        'lat' => '$faker->latitude',
+        'latitude' => '$faker->latitude',
+        'lng' => '$faker->longitude',
+        'longitude' => '$faker->longitude',
+        'name' => '$faker->name',
+        'password' => 'bcrypt($faker->password)',
+        'phone' => '$faker->phoneNumber',
+        'phone_number' => '$faker->phoneNumber',
+        'postcode' => '$faker->postcode',
+        'postal_code' => '$faker->postcode',
+        'remember_token' => 'Str::random(10)',
+        'slug' => '$faker->slug',
+        'street' => '$faker->streetName',
+        'address1' => '$faker->streetAddress',
+        'address2' => '$faker->secondaryAddress',
+        'summary' => '$faker->text',
+        'url' => '$faker->url',
+        'user_name' => '$faker->userName',
+        'username' => '$faker->userName',
+        'uuid' => '$faker->uuid',
+        'zip' => '$faker->postcode',
+    ];
+}

--- a/tests/AttributeGenerator/DefaultAttributesGeneratorTest.php
+++ b/tests/AttributeGenerator/DefaultAttributesGeneratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\Tests\AttributeGenerator;
+
+use Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator\DefaultAttributesGenerator;
+use Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator\TableColumnTypeReader;
+use ExampleApp\Models\Group;
+
+class DefaultAttributesGeneratorTest extends AttributeGeneraterBaseTestCase
+{
+    protected $tableColumnTypeReaderStub;
+
+    public function columnTypesToFakerProvider()
+    {
+        return collect(self::$columnTypesToFakerMap)->map(fn($type, $column) => [$column, $type])->values()->all();
+    }
+
+    public function columnNamesToFakerProvider()
+    {
+        return collect(self::$columnTypesToFakerMap)->map(fn($type, $column) => [$column, $type])->values()->all();
+    }
+
+    /**
+     * @dataProvider columnTypesToFakerProvider
+     * @test
+     */
+    public function it_generates_correct_fake_data_for_column_type(string $name, string $expected)
+    {
+        $generator = new DefaultAttributesGenerator(Group::class);
+        $definitions = $generator->getDefinitions();
+
+        // ignore whitespace, we just care about getting it right
+        $expected = preg_replace('/\s/', '', $expected);
+        $actual = preg_replace('/\s/', '', $definitions->get($name));
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider columnNamesToFakerProvider
+     * @test
+     */
+    public function it_generates_correct_fake_data_for_column_name(string $name, string $expected)
+    {
+        $generator = new DefaultAttributesGenerator(Group::class);
+        $definitions = $generator->getDefinitions();
+
+        // ignore whitespace, we just care about getting it right
+        $expected = preg_replace('/\s/', '', $expected);
+        $actual = preg_replace('/\s/', '', $definitions->get($name));
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function it_generates_code_block_correctly()
+    {
+        $this->withoutExceptionHandling();
+        $generator = new DefaultAttributesGenerator(Group::class);
+        $codeBlock = $generator->getDefinitionsCodeBlock();
+
+        $expected = collect(self::$columnTypesToFakerMap)
+            ->map(fn($fakedValue, $column) => "'$column' => $fakedValue")
+            ->join(",\n            ");
+        $expected = "return [\n            $expected\n        ];";
+
+        $this->assertSame($expected, $codeBlock);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tableColumnTypeReaderStub = $this->createStub(TableColumnTypeReader::class);
+
+        $this->tableColumnTypeReaderStub->method('getColumnTypeMap')
+            ->willReturn(collect(self::$columnTypeMap));
+
+        $this->swap(TableColumnTypeReader::class, $this->tableColumnTypeReaderStub);
+    }
+}

--- a/tests/AttributeGenerator/TableColumnTypeReaderTest.php
+++ b/tests/AttributeGenerator/TableColumnTypeReaderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Christophrumpel\LaravelFactoriesReloaded\Tests\AttributeGenerator;
+
+use Christophrumpel\LaravelFactoriesReloaded\AttributeGenerator\TableColumnTypeReader;
+use Doctrine\DBAL\DBALException;
+
+class TableColumnTypeReaderTest extends AttributeGeneraterBaseTestCase
+{
+    /** @test */
+    public function it_gets_the_correct_column_type_map()
+    {
+        $this->app->bind('db.connection', function () {
+            $connectionMock = \Mockery::mock('connection');
+            $builderMock = \Mockery::mock('builder');
+
+            $connectionMock->shouldReceive('getSchemaBuilder')
+                ->andReturn($builderMock);
+
+            $builderMock->shouldReceive('getColumnListing')
+                ->andReturn(array_keys(self::$columnTypeMap));
+
+            foreach (self::$columnTypeMap as $column => $type) {
+                $builderMock->shouldReceive('getColumnType')
+                    ->with('fake_table', $column)
+                    ->andReturn($type);
+            }
+
+            return $connectionMock;
+        });
+
+        $columnsTypeMap = app(TableColumnTypeReader::class)->getColumnTypeMap('fake_table');
+
+        $this->assertEquals(self::$columnTypeMap, $columnsTypeMap->toArray());
+    }
+
+    /** @test */
+    public function it_returns_unknown_type_when_column_type_is_not_supported()
+    {
+        $this->app->bind('db.connection', function () {
+            $connectionMock = \Mockery::mock('connection');
+            $builderMock = \Mockery::mock('builder');
+
+            $connectionMock->shouldReceive('getSchemaBuilder')
+                ->andReturn($builderMock);
+
+            $builderMock->shouldReceive('getColumnListing')
+                ->andReturn(array_keys(self::$columnTypeMap));
+            $builderMock->shouldReceive('getColumnType')
+                ->andThrow(DBALException::class);
+
+            return $connectionMock;
+        });
+
+        $columnsTypeMap = app(TableColumnTypeReader::class)->getColumnTypeMap('fake_table');
+
+        $expected = collect(self::$columnTypeMap)->map(fn($type) => TableColumnTypeReader::UNKNOWN_TYPE);
+        $this->assertEquals($expected->toArray(), $columnsTypeMap->toArray());
+    }
+}


### PR DESCRIPTION
This will setup fake data for defaults rather than returning an empty array. The goal of this is to give developers a little more of a head start with defining the fake data for their columns. It's not the smartest, but it works well enough for simple column types.

Currently it just supports the basic types that Doctrine DBal supports, since testing was proving a lot more difficult when trying to add support for more types, and some common column names.
All the credit really goes to @mpociot's work in his [laravel-test-factor-helper](https://github.com/mpociot/laravel-test-factory-helper) package.

Let me know if you have any suggestions. The tests were the hardest part of all of this and I'm not 100% satisfied with them, but they do the job so 🤷‍♂️