### PR TITLE
Allowing unfillable fields to be filled by the factory

### DIFF
--- a/config/factories-reloaded.php
+++ b/config/factories-reloaded.php
@@ -24,4 +24,10 @@ return [
      * They are used while generating new factories.
      */
     'vanilla_factories_path' => database_path('factories'),
+
+    /**
+     * Defines whether or not models should be unguarded before building
+     * instances. This allows using unfillable fields in factories.
+     */
+    'unguard_models' => false,
 ];

--- a/example/database/migrations/2020_01_30_0000_create_groups_table.php
+++ b/example/database/migrations/2020_01_30_0000_create_groups_table.php
@@ -17,6 +17,7 @@ class CreateGroupsTable extends Migration
             $table->bigIncrements('id');
             $table->string('name');
             $table->integer('size');
+            $table->string('mobile')->nullable();
             $table->timestamps();
         });
     }

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -38,8 +38,7 @@ abstract class BaseFactory implements FactoryInterface
     protected function build(array $extra = [], string $creationType = 'create')
     {
         $modelData = $this->prepareModelData($creationType, $this->getDefaults($this->faker));
-
-        $model = $this->modelClass::unguarded(fn () => $this->modelClass::$creationType(array_merge($modelData, $this->overwriteDefaults, $extra)));
+        $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType(array_merge($modelData, $this->overwriteDefaults, $extra)));
 
         if ($this->relatedModelFactories->isEmpty()) {
             return $model;
@@ -55,6 +54,15 @@ abstract class BaseFactory implements FactoryInterface
         }
 
         return $model->setRelation($this->relatedModelRelationshipName, $relatedModels);
+    }
+
+    protected function unguardedIfNeeded(\Closure $closure)
+    {
+        if (! config('factories-reloaded.unguard_models')) {
+            return $closure();
+        }
+
+        return $this->modelClass::unguarded($closure);
     }
 
     public function times(int $times = 1): MultiFactoryCollection

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -38,7 +38,8 @@ abstract class BaseFactory implements FactoryInterface
     protected function build(array $extra = [], string $creationType = 'create')
     {
         $modelData = $this->prepareModelData($creationType, $this->getDefaults($this->faker));
-        $model = $this->modelClass::$creationType(array_merge($modelData, $this->overwriteDefaults, $extra));
+
+        $model = $this->modelClass::unguarded(fn () => $this->modelClass::$creationType(array_merge($modelData, $this->overwriteDefaults, $extra)));
 
         if ($this->relatedModelFactories->isEmpty()) {
             return $model;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -155,10 +155,11 @@ class FactoryTest extends TestCase
         // Faker unique mobile number exists for en_SG
         Config::set('app.faker_locale', 'en_SG');
 
-        $this->assertIsString(GroupFactoryUsingFaker::new()
-            ->create()->name);
-        $this->assertIsInt(GroupFactoryUsingFaker::new()
-            ->create()->size);
+        $group = GroupFactoryUsingFaker::new()->create();
+
+        $this->assertIsString($group->name);
+        $this->assertIsInt($group->size);
+        $this->assertIsString($group->mobile);
     }
 
     /** @test * */

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -149,8 +149,23 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_fills_field_that_is_not_fillable(): void
+    public function it_does_not_fill_field_that_is_not_fillable_according_to_config(): void
     {
+        config()->set('factories-reloaded.unguard_models', false);
+
+        $group = GroupFactory::new()->create([
+            'mobile' => 'fake-mobile',
+        ]);
+
+        $this->assertFalse($group->isFillable('mobile'));
+        $this->assertNull($group->mobile);
+    }
+
+    /** @test */
+    public function it_fills_field_that_is_not_fillable_according_to_config(): void
+    {
+        config()->set('factories-reloaded.unguard_models', true);
+
         $group = GroupFactory::new()->create([
             'mobile' => 'fake-mobile',
         ]);
@@ -162,6 +177,9 @@ class FactoryTest extends TestCase
     /** @test * */
     public function it_lets_you_use_faker_for_defining_data(): void
     {
+        // We need `unguard_models` to be `true` here because `mobile` is not fillable.
+        config()->set('factories-reloaded.unguard_models', true);
+
         // Set local to en_SG so that we can test that also local faker data is being used
         // Faker unique mobile number exists for en_SG
         Config::set('app.faker_locale', 'en_SG');

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -148,6 +148,17 @@ class FactoryTest extends TestCase
         $this->assertEquals('Pancakes', $pancakes->first()->name);
     }
 
+    /** @test */
+    public function it_fills_field_that_is_not_fillable(): void
+    {
+        $group = GroupFactory::new()->create([
+            'mobile' => 'fake-mobile',
+        ]);
+
+        $this->assertFalse($group->isFillable('mobile'));
+        $this->assertIsString($group->mobile);
+    }
+
     /** @test * */
     public function it_lets_you_use_faker_for_defining_data(): void
     {


### PR DESCRIPTION
Currently only fillable fields are filled by factories. This PR solves this the same way Laravel factories do. Unguarding did cause another test to fail, but that test didn’t seem to actually test what it was about. I solved that too. 

Things I’m not sure about:
* Does it all belong in one PR?
* Fillable doesn’t seem to be adjustable on the fly, so I left one field out of there. I did add an assertion to make sure it’s actually not fillable, but is it a good enough solution or should we think of something else?
* I used the `mobile` field which was already in a text. This also wasn’t in the migration. That’s fixed, but does it make a good example to have a mobile field on a group?