### PR TITLE
Support factories on overwritten default fields

### DIFF
--- a/example/tests/Factories/RecipeFactory.php
+++ b/example/tests/Factories/RecipeFactory.php
@@ -3,6 +3,7 @@
 namespace ExampleAppTests\Factories;
 
 use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use ExampleApp\Models\Group;
 use ExampleApp\Models\Recipe;
 use Faker\Generator;
 
@@ -39,6 +40,20 @@ class RecipeFactory extends BaseFactory
     {
         return tap(clone $this)->overwriteDefaults([
             'name' => 'my-name',
+        ]);
+    }
+
+    public function withGroup(): self
+    {
+        return tap(clone $this)->overwriteDefaults([
+            'group_id' => GroupFactory::new(),
+        ]);
+    }
+
+    public function withLaravelGroup(): self
+    {
+        return tap(clone $this)->overwriteDefaults([
+            'group_id' => factory(Group::class),
         ]);
     }
 }

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -37,8 +37,11 @@ abstract class BaseFactory implements FactoryInterface
 
     protected function build(array $extra = [], string $creationType = 'create')
     {
-        $modelData = $this->prepareModelData($creationType, $this->getDefaults($this->faker));
-        $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType(array_merge($modelData, $this->overwriteDefaults, $extra)));
+        $modelData = $this->prepareModelData(
+            $creationType,
+            array_merge($this->getDefaults($this->faker), $this->overwriteDefaults, $extra)
+        );
+        $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType($modelData));
 
         if ($this->relatedModelFactories->isEmpty()) {
             return $model;

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -38,7 +38,6 @@ abstract class BaseFactory implements FactoryInterface
     protected function build(array $extra = [], string $creationType = 'create')
     {
         $modelData = $this->prepareModelData(
-            $creationType,
             array_merge($this->getDefaults($this->faker), $this->overwriteDefaults, $extra)
         );
         $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType($modelData));

--- a/src/TranslatesFactoryData.php
+++ b/src/TranslatesFactoryData.php
@@ -11,12 +11,12 @@ trait TranslatesFactoryData
         return $item instanceof BaseFactory || $item instanceof FactoryBuilder;
     }
 
-    private function prepareModelData(string $creationType, array $defaultModelFields): array
+    private function prepareModelData(array $defaultModelFields): array
     {
         return collect($defaultModelFields)
-            ->map(function ($item) use ($creationType) {
+            ->map(function ($item) {
                 if ($this->isFactory($item)) {
-                    return $creationType === 'create' ? $item->create()->id : null;
+                    return $item->create()->id;
                 }
 
                 return $item;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -258,10 +258,54 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
+    public function it_works_with_factory_as_relationship_in_state(): void
+    {
+        $recipe = RecipeFactory::new()->withGroup()->create();
+
+        $this->assertInstanceOf(Recipe::class, $recipe);
+        $this->assertEquals(1, $recipe->group_id);
+        $this->assertCount(1, Recipe::all());
+        $this->assertCount(1, Group::all());
+    }
+
+    /** @test */
+    public function it_works_with_factory_as_relationship_in_extras(): void
+    {
+        $recipe = RecipeFactory::new()->create(['group_id' => GroupFactory::new()]);
+
+        $this->assertInstanceOf(Recipe::class, $recipe);
+        $this->assertEquals(1, $recipe->group_id);
+        $this->assertCount(1, Recipe::all());
+        $this->assertCount(1, Group::all());
+    }
+
+    /** @test */
     public function it_works_with_laravel_factory_as_relationship(): void
     {
         $recipe = RecipeFactoryUsingLaravelFactoryForRelationship::new()->create();
 
+        $this->assertEquals(1, $recipe->group_id);
+        $this->assertCount(1, Recipe::all());
+        $this->assertCount(1, Group::all());
+    }
+
+    /** @test */
+    public function it_works_with_laravel_factory_as_relationship_in_state(): void
+    {
+        $recipe = RecipeFactory::new()->withLaravelGroup()->create();
+
+        $this->assertInstanceOf(Recipe::class, $recipe);
+        $this->assertEquals(1, $recipe->group_id);
+        $this->assertCount(1, Recipe::all());
+        $this->assertCount(1, Group::all());
+    }
+
+    /** @test */
+    public function it_works_with_laravel_factory_as_relationship_in_extras(): void
+    {
+        $recipe = RecipeFactory::new()->create(['group_id' => factory(Group::class)]);
+
+        $this->assertInstanceOf(Recipe::class, $recipe);
         $this->assertEquals(1, $recipe->group_id);
         $this->assertCount(1, Recipe::all());
         $this->assertCount(1, Group::all());


### PR DESCRIPTION
This PR allows to use the factory syntax in overwritten defaults fields.
```php
public function withGroup(): self
{
    return tap(clone $this)->overwriteDefaults([
        'group_id' => GroupFactory::new(),
    ]);
}
```

It will also work with extra attributes:
```php
$recipe = RecipeFactory::new()->create(['group_id' => GroupFactory::new()]);
```

On the current release, I had the following error when using factory:
`Error : Object of class Tests\Factories\GroupFactory could not be converted to string`.

The PR includes some tests.
Two tests are failing. It looks like it's caused by my line \r\n line endings on Windows. Do you have any idea @christophrumpel?
What do you think about this PR?

Thanks