### PR TITLE
Support relations stack & foreign relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Here were are getting a user instance that has three related recipes attached. T
 
 > :warning: **Note**: For this to work, you need to have a new RecipeFactory already created.
 
+You can create many related models instances by chaining `with`s.
+
+```php
+$recipe = RecipeFactory::new()
+    ->with(Group::class, 'group')
+    ->with(Ingredient::class, 'ingredients')
+    ->with(Ingredient::class, 'ingredients', 3)
+    ->create();
+```
+
+Here we are getting a recipe that has a group and four ingredients.
+
+> :warning: **Note**: Up to the version 1.0.8, only the last `with` relation is built.
+
 In Laravel factories, you could also define a related model in your default data like:
 
 ```php

--- a/example/app/Models/Recipe.php
+++ b/example/app/Models/Recipe.php
@@ -3,8 +3,20 @@
 namespace ExampleApp\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Recipe extends Model
 {
     protected $fillable = ['name', 'description', 'group_id'];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    public function ingredients(): BelongsToMany
+    {
+        return $this->belongsToMany(Ingredient::class);
+    }
 }

--- a/example/database/migrations/2020_06_09_0000_create_ingredient_recipe_table.php
+++ b/example/database/migrations/2020_06_09_0000_create_ingredient_recipe_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateIngredientRecipeTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ingredient_recipe', function (Blueprint $table) {
+            $table->unsignedBigInteger('ingredient_id');
+            $table->unsignedBigInteger('recipe_id');
+            $table->primary(['ingredient_id', 'recipe_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('ingredient_recipe');
+    }
+}

--- a/example/tests/Factories/IngredientFactory.php
+++ b/example/tests/Factories/IngredientFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ExampleAppTests\Factories;
+
+use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use ExampleApp\Models\Ingredient;
+use Faker\Generator;
+
+class IngredientFactory extends BaseFactory
+{
+    protected string $modelClass = Ingredient::class;
+
+    public function create(array $extra = []): Ingredient
+    {
+        return parent::build($extra);
+    }
+
+    public function make(array $extra = []): Ingredient
+    {
+        return parent::build($extra, 'make');
+    }
+
+    public function getDefaults(Generator $faker): array
+    {
+        return [
+            'name' => 'Pasta',
+            'description' => 'Good pasta!',
+        ];
+    }
+}


### PR DESCRIPTION
Hi,
This PR allows to create many related models at once. It also add support of BelongsTo and MorphTo relationship.

```php
$recipe = RecipeFactory::new()
            ->with(Group::class, 'group')
            ->andWith(Ingredient::class, 'ingredients', 3)
            ->create();

$this->assertCount(1, Group::all());
$this->assertCount(3, Ingredient::all());
$this->assertTrue($recipe->group()->exists());
$this->assertEquals(3, $recipe->ingredients()->count());
```

To prevent a BC, the relation stack is reset every time `with` is called.
With this implementation, the same relation doesn't add up and only the last o


Here are some things that can be improved:
* define the expected behaviour of the `make` creation type,
* externalize the relations build mecanism,
* define relation creation type according to the relation type (and not the method),
* define if the same relation should stack:
```php
$recipe = RecipeFactory::new()
            ->with(Ingredient::class, 'ingredients', 1)
            ->andWith(Ingredient::class, 'ingredients', 3)
            ->create();
$this->assertCount(3, Ingredient::all());
$this->assertCount(4, Ingredient::all()); /* Or */ 
```

What do you think about this @christophrumpel?
