### PR TITLE
Use `getKey()` instead of hardcoded `id`

### DIFF
--- a/src/TranslatesFactoryData.php
+++ b/src/TranslatesFactoryData.php
@@ -16,7 +16,7 @@ trait TranslatesFactoryData
         return collect($defaultModelFields)
             ->map(function ($item) {
                 if ($this->isFactory($item)) {
-                    return $item->create()->id;
+                    return $item->create()->getKey();
                 }
 
                 return $item;


### PR DESCRIPTION
This PR replaces the hardcoded `id` with `getKey()` when using factories in data. As discussed in #54.