### PR TITLE
Support closures for model data

### DIFF
--- a/example/tests/Factories/IngredientFactoryUsingClosure.php
+++ b/example/tests/Factories/IngredientFactoryUsingClosure.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ExampleAppTests\Factories;
+
+use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use ExampleApp\Models\Ingredient;
+use Faker\Generator;
+
+class IngredientFactoryUsingClosure extends BaseFactory
+{
+    protected string $modelClass = Ingredient::class;
+
+    public function create(array $extra = []): Ingredient
+    {
+        return parent::build($extra);
+    }
+
+    public function make(array $extra = []): Ingredient
+    {
+        return parent::build($extra, 'make');
+    }
+
+    public function getDefaults(Generator $faker): array
+    {
+        return [
+            'name' => 'Pasta',
+            'description' => function (array $ingredient) {
+                return "Super delicious {$ingredient['name']}";
+            },
+        ];
+    }
+}

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -37,7 +37,7 @@ abstract class BaseFactory implements FactoryInterface
 
     protected function build(array $extra = [], string $creationType = 'create')
     {
-        $modelData = $this->transformFactoriesToRelationIds(
+        $modelData = $this->transformModelFields(
             array_merge($this->getDefaults($this->faker), $this->overwriteDefaults, $extra)
         );
         $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType($modelData));

--- a/src/TranslatesFactoryData.php
+++ b/src/TranslatesFactoryData.php
@@ -11,16 +11,30 @@ trait TranslatesFactoryData
         return $item instanceof BaseFactory || $item instanceof FactoryBuilder;
     }
 
-    private function transformFactoriesToRelationIds(array $defaultModelFields): array
+    private static function isCallable($field): bool
     {
-        return collect($defaultModelFields)
-            ->map(function ($item) {
-                if ($this->isFactory($item)) {
-                    return $item->create()->getKey();
-                }
+        return is_callable($field) && ! is_string($field) && ! is_array($field);
+    }
 
-                return $item;
-            })
-            ->toArray();
+    private function transformModelFields(array $defaultModelFields): array
+    {
+        foreach ($defaultModelFields as &$field) {
+            $field = $this->transformField($field, $defaultModelFields);
+        }
+
+        return $defaultModelFields;
+    }
+
+    private function transformField($field, array $defaultModelFields)
+    {
+        if ($this->isFactory($field)) {
+            return $field->create()->getKey();
+        }
+
+        if ($this->isCallable($field)) {
+            return $field($defaultModelFields);
+        }
+
+        return $field;
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,14 +2,15 @@
 
 namespace Christophrumpel\LaravelFactoriesReloaded\Tests;
 
-use ExampleApp\Models\Group;
-use ExampleApp\Models\Ingredient;
-use ExampleApp\Models\Recipe;
 use ExampleAppTests\Factories\GroupFactory;
 use ExampleAppTests\Factories\GroupFactoryUsingFaker;
+use ExampleAppTests\Factories\IngredientFactoryUsingClosure;
 use ExampleAppTests\Factories\RecipeFactory;
 use ExampleAppTests\Factories\RecipeFactoryUsingFactoryForRelationship;
 use ExampleAppTests\Factories\RecipeFactoryUsingLaravelFactoryForRelationship;
+use ExampleApp\Models\Group;
+use ExampleApp\Models\Ingredient;
+use ExampleApp\Models\Recipe;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
@@ -190,6 +191,31 @@ class FactoryTest extends TestCase
         $this->assertIsString($group->name);
         $this->assertIsInt($group->size);
         $this->assertIsString($group->mobile);
+    }
+
+    /** @test * */
+    public function it_lets_you_use_a_closure_for_defining_data(): void
+    {
+        $ingredient = IngredientFactoryUsingClosure::new()->create();
+
+        $this->assertIsString($ingredient->name);
+        $this->assertIsString($ingredient->description);
+        $this->assertEquals($ingredient->name, 'Pasta');
+        $this->assertEquals($ingredient->description, 'Super delicious Pasta');
+    }
+
+    /** @test * */
+    public function it_lets_you_use_a_closure_for_overriding_data(): void
+    {
+        $ingredient = IngredientFactoryUsingClosure::new()->create([
+            'name' => 'Basil',
+            'description' => fn (array $ingredient) => "Super delicious {$ingredient['name']}",
+        ]);
+
+        $this->assertIsString($ingredient->name);
+        $this->assertIsString($ingredient->description);
+        $this->assertEquals($ingredient->name, 'Basil');
+        $this->assertEquals($ingredient->description, 'Super delicious Basil');
     }
 
     /** @test * */

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -194,7 +194,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test * */
-    public function it_lets_you_use_a_closure_for_defining_data(): void
+    public function it_lets_you_use_a_closure_for_defining_default_data(): void
     {
         $ingredient = IngredientFactoryUsingClosure::new()->create();
 
@@ -205,7 +205,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test * */
-    public function it_lets_you_use_a_closure_for_overriding_data(): void
+    public function it_lets_you_use_a_closure_for_overriding_default_data(): void
     {
         $ingredient = IngredientFactoryUsingClosure::new()->create([
             'name' => 'Basil',

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -208,7 +208,7 @@ class FactoryTest extends TestCase
     public function it_lets_you_use_a_closure_for_overriding_default_data(): void
     {
         $ingredient = IngredientFactoryUsingClosure::new()->create([
-            'name' => 'Basil',
+            'name' => fn (array $ingredient) => 'Basil',
             'description' => fn (array $ingredient) => "Super delicious {$ingredient['name']}",
         ]);
 


### PR DESCRIPTION
## What & Why

Currently in the Laravel factories setup, we are able to use a function when defining a field if we rely on data being dynamically set earlier in the factory.

<img width="721" alt="Screen Shot 2020-06-25 at 9 48 32 PM" src="https://user-images.githubusercontent.com/5914258/85821563-c6815f00-b72d-11ea-9c37-44f2c593c983.png">

[https://laravel.com/docs/7.x/database-testing#relationships](https://laravel.com/docs/7.x/database-testing#relationships)

In the library as it stands today, it throws an error when trying to use a closure.

I love this library because I was in the process of transitioning my factories into classes and this library made it so much easier, but I rely on closures a lot for dynamically generating content that is dependent on the fields that are created earlier. I think others who also have already been using closures might find this update useful. 

## Solution
This PR aims to allow closures to be used when setting data in the `getDefaults` method as well as using a closure to override on `make` or `create`. 
