### PR TITLE
Using factories when creating relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Here were are getting a user instance that has three related recipes attached. T
 
 > :warning: **Note**: For this to work, you need to have a new RecipeFactory already created.
 
+You can also define extras for the related models when using related model factories directly.
+
+```php
+$user = UserFactory::new()
+    ->withFactory(RecipeFactory::new()->withCustomName(), 'recipes', 3)
+    ->create();
+```
+
 You can create many related models instances by chaining `with`s.
 
 ```php

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -40,7 +40,7 @@ abstract class BaseFactory implements FactoryInterface
         $modelData = $this->transformModelFields(
             array_merge($this->getDefaults($this->faker), $this->overwriteDefaults, $extra)
         );
-        $model = $this->unguardedIfNeeded(fn () => $this->modelClass::$creationType($modelData));
+        $model = $this->unguardedIfNeeded(fn() => $this->modelClass::$creationType($modelData));
 
         if ($this->relatedModelFactories->isEmpty()) {
             return $model;
@@ -51,7 +51,7 @@ abstract class BaseFactory implements FactoryInterface
 
     protected function unguardedIfNeeded(\Closure $closure)
     {
-        if (! config('factories-reloaded.unguard_models')) {
+        if (!config('factories-reloaded.unguard_models')) {
             return $closure();
         }
 
@@ -68,12 +68,18 @@ abstract class BaseFactory implements FactoryInterface
     /** @return static */
     public function with(string $relatedModelClass, string $relationshipName, int $times = 1): self
     {
+        return $this->withFactory($this->getFactoryFromClassName($relatedModelClass), $relationshipName, $times);
+    }
+
+    /** @return static */
+    public function withFactory(FactoryInterface $relatedFactory, string $relationshipName, int $times = 1): self
+    {
         $clone = clone $this;
 
         $clone->relatedModelFactories = clone $clone->relatedModelFactories;
         $clone->relatedModelFactories[$relationshipName] ??= collect();
         $clone->relatedModelFactories[$relationshipName] = $clone->relatedModelFactories[$relationshipName]->merge(
-            collect()->times($times, fn () => $this->getFactoryFromClassName($relatedModelClass))
+            collect()->times($times, fn() => $relatedFactory)
         );
 
         return $clone;
@@ -97,7 +103,7 @@ abstract class BaseFactory implements FactoryInterface
     protected function getFactoryFromClassName(string $className): FactoryInterface
     {
         $baseClassName = (new ReflectionClass($className))->getShortName();
-        $factoryClass = config('factories-reloaded.factories_namespace').'\\'.$baseClassName.'Factory';
+        $factoryClass = config('factories-reloaded.factories_namespace') . '\\' . $baseClassName . 'Factory';
 
         return new $factoryClass($this->faker);
     }
@@ -120,7 +126,7 @@ abstract class BaseFactory implements FactoryInterface
 
             if (method_exists($relation, 'associate')) {
                 $relatedModels = $factories->map->$creationType();
-                $relatedModels->each(fn ($related) => $relation->associate($related));
+                $relatedModels->each(fn($related) => $relation->associate($related));
 
                 if ($creationType === 'create') {
                     $model->save();
@@ -129,7 +135,7 @@ abstract class BaseFactory implements FactoryInterface
                 continue;
             }
 
-            throw new InvalidArgumentException('Unsupported relation `'.$relationshipName.'` of ` type `'.get_class($relation).'`.');
+            throw new InvalidArgumentException('Unsupported relation `' . $relationshipName . '` of ` type `' . get_class($relation) . '`.');
         }
 
         return $model;


### PR DESCRIPTION
I have started using this package and the very first issue was that I could not create related models with overwritten defaults. Consider the following example: 

```php
GroupFactory::new()->with(Recipe::class, 'recipes')->create();
```

For example, we have no way of defining the name of the related `Recipe` that is being created.

With the new implementation, you can use another factory adding full flexibility for defining the related model.

```php
GroupFactory::new()->withFactory(RecipeFactory::new()->withCustomName(), 'recipes')->create();
```

The API is the same and one can create multiple instances with the same declaration, or chain those as required.