### PR TITLE
Fix $faker->unique() and leverage Laravel's Faker singleton & config

### DIFF
--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -2,7 +2,6 @@
 
 namespace Christophrumpel\LaravelFactoriesReloaded;
 
-use Faker\Factory as FakerFactory;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -30,7 +29,7 @@ abstract class BaseFactory implements FactoryInterface
     /** @return static */
     public static function new(): self
     {
-        $faker = FakerFactory::create(config('app.faker_locale', 'en_US'));
+        $faker = app(Generator::class);
 
         return new static($faker);
     }


### PR DESCRIPTION
Hi,
Laravel configures `Faker\Generator` by default as a singleton and with the right locale:
```php
class DatabaseServiceProvider extends ServiceProvider
{
    //...
    protected function registerEloquentFactory()
    {
        $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
            $locale = $parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US');

            if (! isset(static::$fakers[$locale])) {
                static::$fakers[$locale] = FakerFactory::create($locale);
            }

            static::$fakers[$locale]->unique(true);

            return static::$fakers[$locale];
        });
    };
    //...
}
```
The use of a singleon fixes `$faker->unique()` for this package. 
Prior to this fix, I had random UNIQUE key exceptions because a new container was generated for every intances of Factory. Under the hood, Faker uses an instance of UniqueGenerator for each factory.

This can be cherry-picked in 1.x branch.

Thanks for your package and for the work to support Laravel 8 :)

Regards,
Karel
