### PR TITLE
Make factories immutable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $factory->state(User::class, 'active', function () {
 While creating a new class factory, you will be asked if you like those states to be imported to your new factories. If you agree, you can immediately use them. The state `active` is now a method on your `UserFactory`.
 
 ```php
-$recipe = UserFactory::new()
+$user = UserFactory::new()
     ->active()
     ->create();
 ```
@@ -230,6 +230,40 @@ public function active(): UserFactory
 
 This is recommended for all methods which you will use to setup your test model. If you wouldn't clone the factory, you will always modify the factory itself. This could lead into problems when you use the same factory again.
 
+To make a whole factory immutable by default, set the `$immutable` property to `true`. That way, every state change will automatically return a cloned instance.
+
+```php
+class UserFactory
+{
+    protected string $modelClass = User::class;
+    protected bool $immutable = true;
+
+    // ...
+
+    public function active(): UserFactory
+    {
+        return $this->overwriteDefaults([
+            'active' => true,
+        ]);
+    }
+}
+```
+
+In some context, you might want to use a standard factory as immutable. This can be done with the `immutable` method.
+
+```php
+$factory = UserFactory::new()
+    ->immutable();
+
+$activeUser = $factory
+    ->active()
+    ->create();
+
+$inactiveUser = $factory->create();
+```
+
+> **Note**: `with` and `withFactory` methods are always immutable.
+
 ### What Else
 
 The best thing about those new factory classes is that you `own` them. You can create as many methods or properties as you like to help you create those specific instances that you need. Here is how a more complex factory call could look like:
@@ -241,7 +275,7 @@ UserFactory::new()
     ->withRecipesAndIngredients()
     ->times(10)
     ->create();
-```    
+```
 
 Using such a factory call will help your tests to stay clean and give everyone a good overview of what is happening here.
 

--- a/example/tests/Factories/RecipeFactoryImmutable.php
+++ b/example/tests/Factories/RecipeFactoryImmutable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ExampleAppTests\Factories;
+
+use App\Models\Recipe;
+use Christophrumpel\LaravelFactoriesReloaded\BaseFactory;
+use Faker\Generator;
+
+class RecipeFactoryImmutable extends BaseFactory
+{
+    protected string $modelClass = Recipe::class;
+
+    protected bool $immutable = true;
+
+    public function create(array $extra = []): Recipe
+    {
+        return $this->build($extra);
+    }
+
+    public function make(array $extra = []): Recipe
+    {
+        return $this->build($extra, 'make');
+    }
+
+    public function getDefaults(Generator $faker): array
+    {
+        return [
+            'name' => 'Lasagne',
+            'description' => 'Our family lasagne recipe.',
+        ];
+    }
+
+    public function pasta(): self
+    {
+        return $this->overwriteDefaults([
+            'name' => 'Pasta',
+        ]);
+    }
+
+    public function pizza(): self
+    {
+        return $this->overwriteDefaults([
+            'name' => 'Pizza',
+        ]);
+    }
+}

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -14,6 +14,8 @@ abstract class BaseFactory implements FactoryInterface
 
     protected string $modelClass;
 
+    protected bool $immutable = false;
+
     protected Collection $relatedModelFactories;
 
     protected Generator $faker;
@@ -32,6 +34,14 @@ abstract class BaseFactory implements FactoryInterface
         $faker = app(Generator::class);
 
         return new static($faker);
+    }
+
+    /** @return static */
+    public function immutable(bool $immutable = true): self
+    {
+        $this->immutable = $immutable;
+
+        return $this->immutable ? clone $this : $this;
     }
 
     protected function build(array $extra = [], string $creationType = 'create')
@@ -91,13 +101,15 @@ abstract class BaseFactory implements FactoryInterface
      */
     public function overwriteDefaults($attributes): self
     {
+        $clone = $this->immutable ? clone $this : $this;
+
         if (is_callable($attributes)) {
             $attributes = $attributes();
         }
 
-        $this->overwriteDefaults = array_merge($this->overwriteDefaults, $attributes);
+        $clone->overwriteDefaults = array_merge($clone->overwriteDefaults, $attributes);
 
-        return $this;
+        return $clone;
     }
 
     protected function getFactoryFromClassName(string $className): FactoryInterface

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -9,6 +9,7 @@ use ExampleAppTests\Factories\GroupFactory;
 use ExampleAppTests\Factories\GroupFactoryUsingFaker;
 use ExampleAppTests\Factories\IngredientFactoryUsingClosure;
 use ExampleAppTests\Factories\RecipeFactory;
+use ExampleAppTests\Factories\RecipeFactoryImmutable;
 use ExampleAppTests\Factories\RecipeFactoryUsingFactoryForRelationship;
 use ExampleAppTests\Factories\RecipeFactoryUsingLaravelFactoryForRelationship;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -148,6 +149,39 @@ class FactoryTest extends TestCase
             ->make(['name' => 'Pancakes']);
 
         $this->assertEquals('Pancakes', $pancakes->first()->name);
+    }
+
+    /** @test */
+    public function it_lets_you_create_immutable_factories_by_default(): void
+    {
+        $recipe = RecipeFactoryImmutable::new()->overwriteDefaults(['name' => 'Pasta']);
+        $firstRecipe = $recipe->overwriteDefaults(['name' => 'Pizza'])->create();
+        $secondRecipe = $recipe->create();
+
+        $this->assertEquals('Pizza', $firstRecipe->name);
+        $this->assertEquals('Pasta', $secondRecipe->name);
+    }
+
+    /** @test */
+    public function it_makes_immutable_factory_methods_immutable(): void
+    {
+        $recipe = RecipeFactoryImmutable::new()->pasta();
+        $firstRecipe = $recipe->pizza()->create();
+        $secondRecipe = $recipe->create();
+
+        $this->assertEquals('Pizza', $firstRecipe->name);
+        $this->assertEquals('Pasta', $secondRecipe->name);
+    }
+
+    /** @test */
+    public function it_lets_you_use_a_mutable_factory_as_immutable(): void
+    {
+        $recipe = RecipeFactory::new()->immutable()->overwriteDefaults(['name' => 'Pasta']);
+        $firstRecipe = $recipe->overwriteDefaults(['name' => 'Pizza'])->create();
+        $secondRecipe = $recipe->create();
+
+        $this->assertEquals('Pizza', $firstRecipe->name);
+        $this->assertEquals('Pasta', $secondRecipe->name);
     }
 
     /** @test */


### PR DESCRIPTION
Hi,

This PR allows to make a factory immutable by default, without having to clone `$this` in every state method.

To make a factory immutable, just set the `$immutable` property to `true`.
To make all factories of a project immutable, user can create an abstract ImmutableFactory.

```php
class ProductFactory extends BaseFactory
{
    protected string $modelClass = Product::class;
    protected bool $immutable = true;

    // ... create and make methods

    public function price(int $price): self
    {
        return $this->overrideDefaults([
            'price' => $price,
        ]);
    }
}
```

I find it particularly usefull with `withFactory`:
```php
$product = ProductFactory::new()->enabled()->vat(20);
$category = CategoryFactory::new()
    ->withFactory($product->price(10)->virtual(), 'products')
    ->withFactory($product->price(100)->shippingFees(5), 'products')
    ->create();
```

Existing factories can be used as immutable using the `immutable()` method.
```php
$group = CategoryFactory::new()->immutable()->create();
```
As it can be breaking, this `immutable` method can be removed.

I'll update the README if you like the idea.

Thanks for you package :)

